### PR TITLE
fix(auth): eliminate hydrate race + persist sign-in across launches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,103 @@ the known fix and it has solved every instance we've seen.
 **Do not** disable plugins, downgrade Jellyfin, or modify our header to
 work around it — those are all dead-ends.
 
+### 5.2 Race-free auth hydration (post-mortem from PR #2)
+
+**Symptom we burned a day on:** sign-in returned `200 OK` with a valid
+`AccessToken`, but the very next request — `GET /Users/{id}/Views` —
+returned `401`. Every subsequent library / home / artist / genre request
+also 401’d. The token *was* being persisted to secure storage; the user
+was just being kicked back to onboarding on every app launch.
+
+**Root cause:** `AuthNotifier` was hydrated lazily with the cascade
+`AuthNotifier(...)..hydrate()`. `hydrate()` is an async call into
+`flutter_secure_storage`. On Android, **flutter_secure_storage serializes
+all calls on a single MethodChannel** — reads and writes interleave on
+one queue. At sign-in time the queue looked like:
+
+```
+load()    ← hydrate, started when authProvider was first read
+write()   ← save, called by sign-in screen with the new auth
+```
+
+`load()` returned `null` (storage was empty pre-sign-in) and set
+`state = null` — **after** the sign-in screen had synchronously set
+`state = auth` but **before** the write finished. The token landed in
+secure storage; the in-memory state did not. `jellyfinClientProvider`
+rebuilt with `auth == null`, so every follow-up request flew without a
+`Token=` in the header.
+
+**The pattern we use now (`lib/state/providers.dart`, `lib/main.dart`):**
+
+1. `main()` reads `AuthStorage().load()` **synchronously** (in parallel
+   with `loadOrCreateDeviceId()`) before `runApp`.
+2. The result is injected into the provider tree via an override:
+   ```dart
+   ProviderScope(overrides: [
+     deviceIdProvider.overrideWithValue(deviceId),
+     initialAuthProvider.overrideWithValue(initialAuth),
+     …
+   ])
+   ```
+3. `AuthNotifier` takes the initial value through its constructor:
+   ```dart
+   AuthNotifier(this._storage, {JellyfinAuth? initial}) : super(initial);
+   ```
+   No async hydrate. No race window.
+4. `save(auth)` does `state = auth; await _storage.save(auth);` — nothing
+   is competing to overwrite `state` because the load already happened
+   before the widget tree was even built.
+
+**Rules to keep this race dead:**
+- **Never** add a second async hydrator that runs after construction.
+- **Never** read `authProvider` lazily for the first time *during*
+  sign-in. If you need a new provider that depends on auth, watch
+  `authProvider` from the start — don't `ref.read(authProvider.notifier)`
+  for the side-effect of building it.
+- The boot trace logs `aetherfin:boot device id loaded (len=22); auth
+  restored for <userName>` (or `auth absent`). If you don't see this line
+  before `runApp returned`, the override is missing.
+
+### 5.3 Router-level auth redirects
+
+`go_router` has no built-in awareness of Riverpod state, so we wire it up
+explicitly in `lib/app/router.dart`:
+
+```dart
+final refresh = _AuthRefreshListenable();
+ref.listen<JellyfinAuth?>(authProvider, (_, __) => refresh._notify());
+
+return GoRouter(
+  refreshListenable: refresh,
+  redirect: (context, state) {
+    final auth = ref.read(authProvider);
+    final inOnboarding =
+        state.matchedLocation == '/' ||
+        state.matchedLocation.startsWith('/onboarding');
+    if (auth != null && inOnboarding) return '/home';   // signed in → skip onboarding
+    if (auth == null && !inOnboarding) return '/';      // anonymous → back to welcome
+    return null;
+  },
+  …
+);
+```
+
+Rules:
+- **Every new onboarding route must start with `/onboarding/`** so the
+  redirect's prefix check catches it. The bare `/` is also treated as
+  onboarding.
+- **Every post-auth route must NOT start with `/onboarding/`**. Putting a
+  signed-in screen under `/onboarding/*` would make the redirect bounce
+  the user to `/home` forever.
+- After `await authProvider.notifier.save(auth)` you can still call
+  `context.go('/home')` manually. The refreshListenable will also fire,
+  but the explicit `go()` covers the rare frame where the listener
+  hasn't propagated yet.
+- Don't call `context.pop()` on a screen that was reached via
+  `context.go()` — the stack is empty and you'll hit
+  `GoError("There is nothing to pop")`. Guard with `context.canPop()`
+  or fall back to an explicit `context.go('/')`.
+
 ## 6. Build, run, lint, test
 
 ```bash
@@ -189,7 +286,7 @@ output is enough to diagnose most issues without attaching a debugger.
 
 | Prefix | When | Example |
 |---|---|---|
-| `aetherfin:boot` | Boot ordering, AudioService init | `aetherfin:boot first frame painted — kicking AudioService init` |
+| `aetherfin:boot` | Boot ordering, persisted auth restoration, AudioService init | `aetherfin:boot device id loaded (len=22); auth restored for azrim` |
 | `aetherfin:http →` | Outgoing request (method, URL, headers redacted, body redacted if auth-sensitive) | `aetherfin:http → POST http://srv/Users/AuthenticateByName` |
 | `aetherfin:http ←` | Successful response (status, method, URL) | `aetherfin:http ← 200 GET http://srv/System/Info/Public` |
 | `aetherfin:http ✕` | Failed response (status, method, URL) | `aetherfin:http ✕ 500 POST http://srv/Users/AuthenticateByName` |
@@ -258,6 +355,17 @@ seems obvious.
    signed in we hit `/MusicGenres`. Use `FutureProvider.autoDispose`.
 7. **"Build a parallel HTTP client for endpoint X."** Don't. Add a method
    to `JellyfinClient`.
+8. **"Just hydrate `AuthNotifier` asynchronously — it’s a tiny read."**
+   No. flutter_secure_storage serializes on a single MethodChannel; an
+   async hydrate races sign-in `save()` and clobbers the token in memory.
+   Load auth in `main()` and inject via `initialAuthProvider`. (§5.2.)
+9. **"go_router will figure out where to send a signed-in user on cold
+   start."** No. Without `redirect:` + `refreshListenable`, you land on
+   WelcomeScreen even with valid persisted auth. (§5.3.)
+10. **"`context.pop()` is safe on any screen with a back button."** No.
+    Screens reached via `context.go()` have an empty navigator stack and
+    `pop()` raises `GoError("There is nothing to pop")`. Guard with
+    `canPop()` or fall back to `context.go('/')`.
 
 ## 11. Glossary
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/jellyfin/models/server.dart';
+import '../state/providers.dart';
 import '../design_tokens/tokens.dart';
 import '../features/album/album_screen.dart';
 import '../features/artist/artist_screen.dart';
@@ -33,9 +35,32 @@ final routerProvider = Provider<GoRouter>((ref) {
   final rootKey = GlobalKey<NavigatorState>();
   final shellKey = GlobalKey<NavigatorState>();
 
+  // Re-evaluate redirects whenever auth changes so signing in lands you on
+  // /home and signing out drops you back at /.
+  final refresh = _AuthRefreshListenable();
+  ref.listen<JellyfinAuth?>(authProvider, (_, __) => refresh._notify(),
+      fireImmediately: false);
+  ref.onDispose(refresh.dispose);
+
   return GoRouter(
     navigatorKey: rootKey,
     initialLocation: '/',
+    refreshListenable: refresh,
+    redirect: (context, state) {
+      final auth = ref.read(authProvider);
+      final loc = state.matchedLocation;
+      final inOnboarding = loc == '/' || loc.startsWith('/onboarding');
+      if (auth != null && inOnboarding) {
+        // Already signed in — fast-forward past welcome / discovery.
+        return '/home';
+      }
+      if (auth == null && !inOnboarding) {
+        // No credentials — send the user through onboarding before we
+        // try to render any post-auth screen (which would 401 anyway).
+        return '/';
+      }
+      return null;
+    },
     routes: [
       // Onboarding
       GoRoute(
@@ -142,6 +167,13 @@ final routerProvider = Provider<GoRouter>((ref) {
     ],
   );
 });
+
+/// Thin ChangeNotifier we hand to GoRouter so it re-runs `redirect` when
+/// auth state flips. We can't pass `authProvider` directly because
+/// GoRouter expects a Listenable and Riverpod providers are not Listenables.
+class _AuthRefreshListenable extends ChangeNotifier {
+  void _notify() => notifyListeners();
+}
 
 List<GoRoute> _commonChildren() => [
       GoRoute(

--- a/lib/features/onboarding/server_discovery_screen.dart
+++ b/lib/features/onboarding/server_discovery_screen.dart
@@ -113,7 +113,16 @@ class _ServerDiscoveryScreenState extends ConsumerState<ServerDiscoveryScreen> {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_rounded),
-          onPressed: () => context.pop(),
+          onPressed: () {
+            // We arrive here via `context.go()` from WelcomeScreen, which
+            // replaces the stack — so `pop()` raises GoError("nothing to
+            // pop"). Route home explicitly when the stack is empty.
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/');
+            }
+          },
         ),
         title: Text(
           'Find your server',

--- a/lib/features/onboarding/sign_in_screen.dart
+++ b/lib/features/onboarding/sign_in_screen.dart
@@ -62,7 +62,10 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
       }
       await ref.read(authProvider.notifier).save(auth);
       if (!mounted) return;
-      context.go('/onboarding/scope');
+      // Auth flipping non-null triggers the router's redirect to /home;
+      // calling context.go ourselves also covers the rare case where the
+      // refreshListenable hasn't fired yet.
+      context.go('/home');
     } catch (e, stack) {
       // ignore: avoid_print
       print('aetherfin:error sign-in failed: $e');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app/app.dart';
 import 'core/audio/player_service.dart';
 import 'core/jellyfin/auth_storage.dart';
+import 'core/jellyfin/models/server.dart';
 import 'design_tokens/tokens.dart';
 import 'state/providers.dart';
 
@@ -53,25 +54,35 @@ Future<void> main() async {
     ErrorWidget.builder = (details) => _RootErrorWidget(details: details);
     _boot('error handlers installed');
 
-    // Load the stable per-install device ID before mounting the app so
-    // every Jellyfin request uses the same identifier from the very first
-    // frame. A single keystore-backed read is sub-100 ms and avoids the
-    // race where the UI tries to construct a JellyfinClient before the
-    // device ID is available. If the read fails (corrupt keystore, etc.)
-    // we fall back to an in-memory ID rather than blocking the user.
+    // Load the stable per-install device ID + the persisted auth blob
+    // before mounting the app so every Jellyfin request uses the same
+    // identifier from the very first frame, AND so the router can
+    // immediately route an already-signed-in user past the welcome screen
+    // to /home. Two sub-100 ms keystore reads — we await them in parallel
+    // so they don't stack. If either fails (corrupt keystore, etc.) we
+    // fall back gracefully rather than blocking the user.
+    final storage = AuthStorage();
     String deviceId;
+    JellyfinAuth? initialAuth;
     try {
-      deviceId = await AuthStorage().loadOrCreateDeviceId();
-      _boot('device id loaded (len=${deviceId.length})');
+      final results = await Future.wait([
+        storage.loadOrCreateDeviceId(),
+        storage.load(),
+      ]);
+      deviceId = results[0] as String;
+      initialAuth = results[1] as JellyfinAuth?;
+      _boot('device id loaded (len=${deviceId.length}); '
+          'auth ${initialAuth != null ? "restored for ${initialAuth.userName}" : "absent"}');
     } catch (e, stack) {
       // ignore: avoid_print
-      print('aetherfin:error device id load failed: $e');
+      print('aetherfin:error device id / auth load failed: $e');
       // ignore: avoid_print
       print('aetherfin:error stack: $stack');
       // Last-ditch fallback so onboarding can still proceed. The cost is
       // that this install will look like a new device to Jellyfin on
       // every launch until secure storage starts working again.
       deviceId = 'aetherfin-fallback-${DateTime.now().microsecondsSinceEpoch}';
+      initialAuth = null;
     }
 
     // Launch the UI immediately — audio init runs in the background AFTER
@@ -81,6 +92,7 @@ Future<void> main() async {
       ProviderScope(
         overrides: [
           deviceIdProvider.overrideWithValue(deviceId),
+          initialAuthProvider.overrideWithValue(initialAuth),
           playerServiceProvider.overrideWith((ref) {
             // Until AudioService.init resolves, hand out a bare service so
             // the UI doesn't crash if it reads playerServiceProvider before

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -28,17 +28,28 @@ final deviceIdProvider = Provider<String>((ref) {
   );
 });
 
+/// Auth blob loaded synchronously from secure storage at app startup.
+/// Overridden in `main.dart` so that [authProvider]'s initial state is
+/// the persisted auth (if any) — never `null` followed by an async
+/// hydrate() that would race with a sign-in `save()` and clobber it.
+final initialAuthProvider = Provider<JellyfinAuth?>((ref) {
+  throw StateError(
+    'initialAuthProvider was read before being overridden in main(). '
+    'This is a bug — ProviderScope must override it with the value '
+    'returned by AuthStorage.load() (or null when no auth is stored).',
+  );
+});
+
 final authProvider = StateNotifierProvider<AuthNotifier, JellyfinAuth?>((ref) {
-  return AuthNotifier(ref.watch(authStorageProvider))..hydrate();
+  return AuthNotifier(
+    ref.watch(authStorageProvider),
+    initial: ref.watch(initialAuthProvider),
+  );
 });
 
 class AuthNotifier extends StateNotifier<JellyfinAuth?> {
   final AuthStorage _storage;
-  AuthNotifier(this._storage) : super(null);
-
-  Future<void> hydrate() async {
-    state = await _storage.load();
-  }
+  AuthNotifier(this._storage, {JellyfinAuth? initial}) : super(initial);
 
   Future<void> save(JellyfinAuth auth) async {
     state = auth;


### PR DESCRIPTION
## Summary

Two interconnected bugs broke the app after the first APK install:

1. **Every post-auth request returned 401.** Logcat showed `200 OK POST /Users/AuthenticateByName` immediately followed by `401` on every `Users/{id}/Views`, `Items/Latest`, `Artists`, `MusicGenres` request. The home + library screens were stuck on demo data with no obvious failure.
2. **The user was forced through onboarding on every app launch** even though the access token was being persisted to secure storage.

### Bug #1 — root cause: race in `AuthNotifier`

The provider was built as:

```dart
final authProvider = StateNotifierProvider<AuthNotifier, JellyfinAuth?>((ref) {
  return AuthNotifier(ref.watch(authStorageProvider))..hydrate();
});
```

`hydrate()` fires an async `flutter_secure_storage.load()`. On Android, flutter_secure_storage serializes calls on a single MethodChannel, so at sign-in time the queue was:

```
load()   <- hydrate, started when authProvider was first read
write()  <- save, called by sign-in screen with the new auth
```

`load()` returned the value in storage at that moment (null on a fresh install) and set `state = null`. That happened AFTER the sign-in screen synchronously set `state = auth` but BEFORE the write completed — clobbering the in-memory token. The token was correctly persisted to storage, but the JellyfinClient the rest of the app saw was rebuilt with `auth == null`, so every follow-up request went out without a `Token=` in the Authorization header -> 401.

**Fix:** remove `hydrate()` entirely. Auth is now loaded synchronously in `main()` (in parallel with the device-id read) and injected via `initialAuthProvider.overrideWithValue(...)` so `AuthNotifier`'s initial state is correct from the very first frame and nothing competes with the sign-in `save()`.

### Bug #2 — root cause: router has no auth awareness

The router unconditionally landed on `/` (WelcomeScreen) at startup. A GoRouter `redirect:` now routes signed-in users straight to `/home` when they hit any onboarding path, and routes anonymous users back to `/` if they somehow reach a post-auth path. A `_AuthRefreshListenable` re-runs the redirect when auth flips so sign-in / sign-out are picked up immediately.

### Drive-by

`ServerDiscoveryScreen`'s back button no longer raises `GoError("There is nothing to pop")` when the navigator stack is empty (arrived via `context.go()` from welcome) — it falls back to `context.go('/')`.

## Review & Testing Checklist for Human

- [ ] Cold-launch the app with no existing auth — verify you land on WelcomeScreen -> onboarding flow as before.
- [ ] Sign in with valid username/password — verify you land on **/home with real Jellyfin data** (album grid, artists, genres), not demo content.
- [ ] Force-stop the app and reopen — verify you land **directly on /home** without re-entering credentials.
- [ ] Tap the back button on the server-discovery screen — verify the app returns to WelcomeScreen instead of crashing with `GoError: There is nothing to pop`.

### Notes

- `flutter analyze --no-fatal-infos` -> 0 errors (49 pre-existing info-level lints, unchanged).
- `flutter test` -> 7/7 pass.
- No changes to the Authorization header format — that was already byte-aligned with Finamp in `f159d7b`. The 401 was purely a state-management issue on the client.