### PR TITLE
Wire screens to live Jellyfin data; add aetherfin:data trace category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,14 @@ output is enough to diagnose most issues without attaching a debugger.
 | `aetherfin:http ←` | Successful response (status, method, URL) | `aetherfin:http ← 200 GET http://srv/System/Info/Public` |
 | `aetherfin:http ✕` | Failed response (status, method, URL) | `aetherfin:http ✕ 500 POST http://srv/Users/AuthenticateByName` |
 | `aetherfin:error` | Caught exception with full Dio error + stacktrace | (multi-line block) |
+| `aetherfin:data` | Data-source provenance — fires every time a Riverpod provider serves data, marking whether the bytes came from live Jellyfin (`source=live`), the bundled signed-out preview (`source=demo`), or a still-mocked code path (`source=mock`). | `aetherfin:data recentlyAddedAlbums source=live count=20` / `aetherfin:data search source=demo query="rain" tracks=3 albums=1 artists=0` |
+
+`aetherfin:data` lines are emitted by `_logData()` in `lib/state/providers.dart`
+and by `AfPlayerService` / `JellyfinPlaybackReporter` for queue + playback
+events. Use `adb logcat -s flutter | grep aetherfin:data` to spot any screen
+that has regressed onto `DemoLibrary` after sign-in — every signed-in
+session should show `source=live` exclusively (with `source=demo` only on
+the signed-out onboarding preview).
 
 When adding new diagnostics:
 - Always go through `print('aetherfin:<category> …')`. No `debugPrint`,

--- a/lib/core/audio/jellyfin_playback_reporter.dart
+++ b/lib/core/audio/jellyfin_playback_reporter.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import '../jellyfin/client.dart';
+import '../jellyfin/models/items.dart';
+import 'player_service.dart';
+
+/// Pushes playback-session lifecycle events from [AfPlayerService] to the
+/// Jellyfin server so the "Now Playing" widgets, listening history, and
+/// activity feed all reflect what's actually playing.
+///
+/// Wired up in `playerServiceProvider` so the player itself stays
+/// Riverpod-free. [clientGetter] is a *lazy* lookup (called on every
+/// emit) so when auth flips and `jellyfinClientProvider` rebuilds with a
+/// new `JellyfinClient`, the reporter automatically targets the new
+/// server without any re-subscription dance.
+///
+/// Endpoints used (per the Jellyfin REST conventions Finamp + the web
+/// client agree on):
+///   • `POST /Sessions/Playing`           — first emit for a new track
+///   • `POST /Sessions/Playing/Progress`  — every 10s while playing,
+///                                          and once on each pause / resume
+///   • `POST /Sessions/Playing/Stopped`   — when the queue advances, the
+///                                          player stops, or the reporter
+///                                          is disposed
+class JellyfinPlaybackReporter {
+  final AfPlayerService _player;
+  final JellyfinClient? Function() _clientGetter;
+
+  static const _progressInterval = Duration(seconds: 10);
+
+  StreamSubscription<AfTrack?>? _trackSub;
+  StreamSubscription<bool>? _playingSub;
+  Timer? _progressTimer;
+  String? _lastReportedTrackId;
+
+  JellyfinPlaybackReporter(this._player, this._clientGetter) {
+    _trackSub = _player.currentTrackStream.listen(_onTrackChanged);
+    _playingSub = _player.playingStream.listen(_onPlayingChanged);
+  }
+
+  Future<void> _onTrackChanged(AfTrack? track) async {
+    final client = _clientGetter();
+    final previousId = _lastReportedTrackId;
+
+    if (previousId != null && previousId != track?.id) {
+      // Send the stop for the outgoing track before we open a session
+      // for the incoming one — Jellyfin keys the active session by the
+      // last reported start, and overlapping sessions confuse the
+      // activity feed.
+      final position = _player.position;
+      if (client != null) {
+        try {
+          await client.reportPlaybackStop(previousId, position);
+          // ignore: avoid_print
+          print('aetherfin:data playbackStop source=live track=$previousId '
+              'positionMs=${position.inMilliseconds}');
+        } catch (e, stack) {
+          // ignore: avoid_print
+          print('aetherfin:error reportPlaybackStop failed: $e');
+          // ignore: avoid_print
+          print('aetherfin:error stack: $stack');
+        }
+      }
+    }
+
+    if (track == null) {
+      _lastReportedTrackId = null;
+      _stopProgressTimer();
+      return;
+    }
+    if (track.id == previousId) return;
+
+    _lastReportedTrackId = track.id;
+    if (client == null) {
+      // ignore: avoid_print
+      print('aetherfin:data playbackStart source=demo track=${track.id} '
+          '(no JellyfinClient; signed out)');
+      _stopProgressTimer();
+      return;
+    }
+    try {
+      await client.reportPlaybackStart(track.id);
+      // ignore: avoid_print
+      print('aetherfin:data playbackStart source=live track=${track.id} '
+          'title="${track.title}"');
+      _startProgressTimer();
+    } catch (e, stack) {
+      // ignore: avoid_print
+      print('aetherfin:error reportPlaybackStart failed: $e');
+      // ignore: avoid_print
+      print('aetherfin:error stack: $stack');
+    }
+  }
+
+  Future<void> _onPlayingChanged(bool isPlaying) async {
+    final trackId = _lastReportedTrackId;
+    if (trackId == null) return;
+    final client = _clientGetter();
+    if (client == null) return;
+    final position = _player.position;
+    try {
+      await client.reportProgress(
+        trackId,
+        position,
+        isPaused: !isPlaying,
+      );
+      // ignore: avoid_print
+      print('aetherfin:data playbackProgress source=live track=$trackId '
+          'positionMs=${position.inMilliseconds} paused=${!isPlaying}');
+    } catch (e, stack) {
+      // ignore: avoid_print
+      print('aetherfin:error reportProgress (transition) failed: $e');
+      // ignore: avoid_print
+      print('aetherfin:error stack: $stack');
+    }
+    if (isPlaying) {
+      _startProgressTimer();
+    } else {
+      _stopProgressTimer();
+    }
+  }
+
+  void _startProgressTimer() {
+    _stopProgressTimer();
+    _progressTimer = Timer.periodic(_progressInterval, (_) async {
+      final trackId = _lastReportedTrackId;
+      if (trackId == null) return;
+      final client = _clientGetter();
+      if (client == null) return;
+      final position = _player.position;
+      try {
+        await client.reportProgress(trackId, position);
+        // ignore: avoid_print
+        print('aetherfin:data playbackProgress source=live track=$trackId '
+            'positionMs=${position.inMilliseconds} (tick)');
+      } catch (e, stack) {
+        // ignore: avoid_print
+        print('aetherfin:error reportProgress (tick) failed: $e');
+        // ignore: avoid_print
+        print('aetherfin:error stack: $stack');
+      }
+    });
+  }
+
+  void _stopProgressTimer() {
+    _progressTimer?.cancel();
+    _progressTimer = null;
+  }
+
+  Future<void> dispose() async {
+    await _trackSub?.cancel();
+    await _playingSub?.cancel();
+    _stopProgressTimer();
+    final trackId = _lastReportedTrackId;
+    if (trackId == null) return;
+    final client = _clientGetter();
+    if (client == null) return;
+    final position = _player.position;
+    try {
+      await client.reportPlaybackStop(trackId, position);
+      // ignore: avoid_print
+      print('aetherfin:data playbackStop source=live track=$trackId '
+          'positionMs=${position.inMilliseconds} (reporter disposed)');
+    } catch (e, stack) {
+      // ignore: avoid_print
+      print('aetherfin:error reportPlaybackStop (dispose) failed: $e');
+      // ignore: avoid_print
+      print('aetherfin:error stack: $stack');
+    }
+  }
+}

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -15,20 +15,47 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
   final _player = AudioPlayer();
   final _trackQueue = <AfTrack>[];
   int _currentIndex = -1;
+  final _trackController = StreamController<AfTrack?>.broadcast();
+  final _queueController = StreamController<List<AfTrack>>.broadcast();
+
+  /// Called whenever the active track changes (queue advance, manual
+  /// skip, queue replaced). Wired by `playerServiceProvider` so the
+  /// Riverpod layer can keep `currentTrackProvider` in sync and report
+  /// session start/stop to Jellyfin.
+  ///
+  /// Player itself is Riverpod-free so it stays testable without a
+  /// ProviderContainer.
+  void Function(AfTrack track)? onTrackChanged;
 
   AfPlayerService() {
     _player.playbackEventStream.listen(_broadcastPlaybackEvent);
     _player.currentIndexStream.listen((idx) {
       if (idx == null) return;
+      if (idx < 0 || idx >= _trackQueue.length) return;
       _currentIndex = idx;
-      mediaItem.add(_mediaItemFor(_trackQueue[idx]));
+      final track = _trackQueue[idx];
+      mediaItem.add(_mediaItemFor(track));
+      _trackController.add(track);
+      // ignore: avoid_print
+      print(
+        'aetherfin:data currentTrack source=live id=${track.id} '
+        'title="${track.title}" index=$idx',
+      );
+      onTrackChanged?.call(track);
     });
   }
 
   Stream<Duration> get positionStream => _player.positionStream;
   Stream<bool> get playingStream => _player.playingStream;
   Stream<ProcessingState> get stateStream => _player.processingStateStream;
+  /// Broadcast stream of the currently-playing [AfTrack]. Emits whenever
+  /// the queue index advances; emits `null` when the queue is cleared.
+  Stream<AfTrack?> get currentTrackStream => _trackController.stream;
+  /// Broadcast stream of the active queue — emits the same list shape the
+  /// Queue screen renders so it reflects skips / replacements immediately.
+  Stream<List<AfTrack>> get queueStream => _queueController.stream;
   Duration get position => _player.position;
+  List<AfTrack> get currentQueue => List.unmodifiable(_trackQueue);
   AfTrack? get currentTrack =>
       (_currentIndex >= 0 && _currentIndex < _trackQueue.length)
           ? _trackQueue[_currentIndex]
@@ -44,6 +71,7 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
       ..clear()
       ..addAll(tracks);
     queue.add(tracks.map(_mediaItemFor).toList());
+    _queueController.add(List.unmodifiable(_trackQueue));
     final sources = tracks
         .map((t) => AudioSource.uri(
               Uri.parse(resolveStreamUrl(t)),
@@ -55,7 +83,15 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
       initialIndex: startIndex,
     );
     _currentIndex = startIndex;
-    mediaItem.add(_mediaItemFor(tracks[startIndex]));
+    final startTrack = tracks[startIndex];
+    mediaItem.add(_mediaItemFor(startTrack));
+    _trackController.add(startTrack);
+    // ignore: avoid_print
+    print(
+      'aetherfin:data playQueue source=live size=${tracks.length} '
+      'startIndex=$startIndex first="${startTrack.title}"',
+    );
+    onTrackChanged?.call(startTrack);
     await _player.play();
   }
 
@@ -84,6 +120,8 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
 
   Future<void> dispose() async {
     await _player.dispose();
+    await _trackController.close();
+    await _queueController.close();
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -274,18 +274,61 @@ class JellyfinClient {
     return '${server.baseUrl}/Audio/$trackId/universal?$query';
   }
 
+  /// `POST /Sessions/Playing` — tell the server a track just started.
+  ///
+  /// Without this Jellyfin's "Now Playing" / activity widgets stay blank
+  /// even though `/Audio/{id}/universal` is streaming. Mirrors Finamp's
+  /// reportPlaybackStart() — ItemId + PositionTicks (always 0 at start) +
+  /// PlayMethod=DirectStream so the dashboard doesn't render "Transcoding"
+  /// while we're actually direct-playing the cached AAC the server picked.
+  Future<void> reportPlaybackStart(String trackId) async {
+    _assertUser();
+    await _dio.post(
+      'Sessions/Playing',
+      data: {
+        'ItemId': trackId,
+        'PositionTicks': 0,
+        'PlayMethod': 'DirectStream',
+        'CanSeek': true,
+      },
+    );
+  }
+
   /// `POST /Sessions/Playing/Progress` — playback progress reporting.
+  ///
+  /// Called on a ~10s cadence while playing, and once on every pause/seek.
+  /// Sending more often than 10s is wasted bandwidth — Jellyfin's web
+  /// client and Finamp both use that interval.
   Future<void> reportProgress(
     String trackId,
     Duration position, {
     bool isPaused = false,
   }) async {
+    _assertUser();
     await _dio.post(
       'Sessions/Playing/Progress',
       data: {
         'ItemId': trackId,
         'PositionTicks': position.inMicroseconds * 10,
         'IsPaused': isPaused,
+        'PlayMethod': 'DirectStream',
+      },
+    );
+  }
+
+  /// `POST /Sessions/Playing/Stopped` — tell the server playback stopped
+  /// (queue ended, user stopped, app backgrounded long enough to dispose).
+  ///
+  /// We send POST .../Stopped rather than DELETE /Sessions/Playing because
+  /// that's the path Finamp and the Jellyfin web client use and it works
+  /// reliably on plugin-heavy installs where DELETE bodies get stripped.
+  Future<void> reportPlaybackStop(String trackId, Duration position) async {
+    _assertUser();
+    await _dio.post(
+      'Sessions/Playing/Stopped',
+      data: {
+        'ItemId': trackId,
+        'PositionTicks': position.inMicroseconds * 10,
       },
     );
   }
@@ -471,6 +514,31 @@ class JellyfinClient {
       },
     );
     return _parseItemList(res.data).map(_parseAlbum).toList(growable: false);
+  }
+
+  /// `GET /Users/{userId}/Items?ArtistIds=…&SortBy=PlayCount` — the artist's
+  /// most-played tracks, used to populate the "Top songs" rail on the
+  /// artist screen. Falls back to alphabetical when the server has no play
+  /// counts (fresh library / first sign-in).
+  Future<List<AfTrack>> artistTopTracks(
+    String artistId, {
+    int limit = 5,
+  }) async {
+    _assertUser();
+    final res = await _dio.get<Map<String, dynamic>>(
+      'Users/$userId/Items',
+      queryParameters: <String, dynamic>{
+        'ArtistIds': artistId,
+        'IncludeItemTypes': 'Audio',
+        'Recursive': true,
+        'SortBy': 'PlayCount,SortName',
+        'SortOrder': 'Descending,Ascending',
+        'Limit': limit,
+        'Fields': _trackFields,
+        'EnableImages': true,
+      },
+    );
+    return _parseItemList(res.data).map(_parseTrack).toList(growable: false);
   }
 
   /// `GET /Users/{userId}/Items?searchTerm=…` — full-text search across the

--- a/lib/core/jellyfin/models/server.dart
+++ b/lib/core/jellyfin/models/server.dart
@@ -53,6 +53,13 @@ class JellyfinServer {
 }
 
 /// Jellyfin user credentials returned from `/Users/AuthenticateByName`.
+///
+/// Note: the Authorization header is built freshly per-client in
+/// `JellyfinClient._buildAuthHeader()` so it can pick up the
+/// per-install random `DeviceId` from secure storage. There is
+/// intentionally no `authHeader` getter here — hard-coding
+/// `DeviceId="aetherfin-android"` was the source of CLAUDE.md §10
+/// footgun #2 and we never want it brought back.
 class JellyfinAuth {
   final JellyfinServer server;
   final String userId;
@@ -65,10 +72,4 @@ class JellyfinAuth {
     required this.userName,
     required this.accessToken,
   });
-
-  /// Bearer-style header value for the X-Emby-Authorization scheme used
-  /// by Jellyfin (the access token goes in the same header rather than
-  /// in `Authorization: Bearer …`).
-  String get authHeader =>
-      'MediaBrowser Client="Aetherfin", Device="Android", DeviceId="aetherfin-android", Version="0.1.0", Token="$accessToken"';
 }

--- a/lib/features/artist/artist_screen.dart
+++ b/lib/features/artist/artist_screen.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/demo/demo_library.dart';
+import '../../core/audio/play_actions.dart';
+import '../../core/jellyfin/models/items.dart';
 import '../../design_tokens/tokens.dart';
 import '../../state/providers.dart';
 import '../../widgets/artwork.dart';
@@ -24,13 +25,16 @@ class ArtistScreen extends ConsumerWidget {
         error: (_, __) => const Center(child: Icon(Icons.error_outline)),
         data: (artist) {
           if (artist == null) return const Center(child: Text('Not found'));
-          final albums = DemoLibrary.albums
-              .where((a) => a.artistName == artist.name)
-              .toList();
-          final topTracks = DemoLibrary.tracks
-              .where((t) => t.artistName == artist.name)
-              .take(5)
-              .toList();
+          final albumsAsync = ref.watch(artistAlbumsProvider(artistId));
+          final topTracksAsync = ref.watch(artistTopTracksProvider(artistId));
+          final albums = albumsAsync.maybeWhen(
+            data: (a) => a,
+            orElse: () => const <AfAlbum>[],
+          );
+          final topTracks = topTracksAsync.maybeWhen(
+            data: (t) => t,
+            orElse: () => const <AfTrack>[],
+          );
           return CustomScrollView(
             physics: const ClampingScrollPhysics(),
             slivers: [
@@ -117,7 +121,12 @@ class ArtistScreen extends ConsumerWidget {
                       for (final t in topTracks)
                         Padding(
                           padding: const EdgeInsets.only(bottom: 4),
-                          child: TrackRow(track: t),
+                          child: TrackRow(
+                            track: t,
+                            onTap: () => ref
+                                .read(playActionsProvider)
+                                .playSingle(t),
+                          ),
                         ),
                     ],
                   ),

--- a/lib/features/lyrics/lyrics_screen.dart
+++ b/lib/features/lyrics/lyrics_screen.dart
@@ -9,25 +9,6 @@ import '../../state/providers.dart';
 class LyricsScreen extends ConsumerWidget {
   const LyricsScreen({super.key});
 
-  static const _demoLrc = '''
-[ti:Driftless]
-[ar:Skylark]
-[al:Neon Cathedral]
-[00:00.00] —
-[00:08.00] We woke up early
-[00:12.00] before the kettle
-[00:18.00] before the radio
-[00:24.00] The window was bright
-[00:32.00] and quiet for once
-[00:40.00] The plants knew
-[00:48.00] before we did
-[00:56.00] that the season had turned
-[01:08.00] A small thing
-[01:16.00] but a clear thing
-[01:28.00] We carried it
-[01:36.00] all through the morning
-''';
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final track = ref.watch(currentTrackProvider);
@@ -36,8 +17,17 @@ class LyricsScreen extends ConsumerWidget {
         positionAsync.maybeWhen(data: (p) => p, orElse: () => Duration.zero);
     final spectral = ref.watch(currentSpectralProvider);
 
-    final lrc = parseLrc(_demoLrc);
-    final active = lrc.activeIndex(position);
+    // Real lyrics from Jellyfin (`/Audio/{id}/Lyrics`). Returns `null` when
+    // the server has none — we render a small empty state below rather
+    // than fall back to the previous hard-coded demo LRC.
+    final lrcAsync = track == null
+        ? const AsyncValue<Lrc?>.data(null)
+        : ref.watch(lyricsProvider(track.id));
+    final lrc = lrcAsync.maybeWhen(
+      data: (parsed) => parsed,
+      orElse: () => null,
+    );
+    final active = lrc?.activeIndex(position) ?? -1;
 
     return Scaffold(
       appBar: AppBar(
@@ -117,36 +107,76 @@ class LyricsScreen extends ConsumerWidget {
                 ),
               ),
               Expanded(
-                child: ListView.builder(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AfSpacing.gutterGenerous,
-                    vertical: AfSpacing.s24,
+                child: lrcAsync.maybeWhen(
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
                   ),
-                  itemCount: lrc.lines.length,
-                  itemBuilder: (context, i) {
-                    final isActive = i == active;
-                    return AnimatedContainer(
-                      duration: AfDurations.quick,
-                      curve: AfCurves.easeOut,
-                      padding:
-                          const EdgeInsets.symmetric(vertical: 8),
-                      child: AnimatedScale(
-                        scale: isActive ? 1.04 : 1.0,
-                        duration: AfDurations.quick,
-                        curve: AfCurves.easeOut,
-                        alignment: Alignment.centerLeft,
-                        child: AnimatedDefaultTextStyle(
-                          duration: AfDurations.quick,
-                          style: AfTypography.titleMedium.copyWith(
-                            color: isActive
-                                ? spectral.energy
-                                : AfColors.textSecondary,
-                            fontWeight:
-                                isActive ? FontWeight.w600 : FontWeight.w400,
-                          ),
-                          child: Text(lrc.lines[i].text),
-                        ),
+                  error: (e, _) => Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AfSpacing.gutterGenerous,
                       ),
+                      child: Text(
+                        'Could not load lyrics: $e',
+                        style: AfTypography.bodySmall.copyWith(
+                          color: AfColors.semanticError,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                  orElse: () {
+                    if (lrc == null || lrc.isEmpty) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AfSpacing.gutterGenerous,
+                          ),
+                          child: Text(
+                            track == null
+                                ? 'Start a track to see lyrics.'
+                                : 'No lyrics available for this track.',
+                            style: AfTypography.bodyMedium.copyWith(
+                              color: AfColors.textTertiary,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      );
+                    }
+                    return ListView.builder(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AfSpacing.gutterGenerous,
+                        vertical: AfSpacing.s24,
+                      ),
+                      itemCount: lrc.lines.length,
+                      itemBuilder: (context, i) {
+                        final isActive = i == active;
+                        return AnimatedContainer(
+                          duration: AfDurations.quick,
+                          curve: AfCurves.easeOut,
+                          padding:
+                              const EdgeInsets.symmetric(vertical: 8),
+                          child: AnimatedScale(
+                            scale: isActive ? 1.04 : 1.0,
+                            duration: AfDurations.quick,
+                            curve: AfCurves.easeOut,
+                            alignment: Alignment.centerLeft,
+                            child: AnimatedDefaultTextStyle(
+                              duration: AfDurations.quick,
+                              style: AfTypography.titleMedium.copyWith(
+                                color: isActive
+                                    ? spectral.energy
+                                    : AfColors.textSecondary,
+                                fontWeight: isActive
+                                    ? FontWeight.w600
+                                    : FontWeight.w400,
+                              ),
+                              child: Text(lrc.lines[i].text),
+                            ),
+                          ),
+                        );
+                      },
                     );
                   },
                 ),

--- a/lib/features/queue/queue_screen.dart
+++ b/lib/features/queue/queue_screen.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/demo/demo_library.dart';
+import '../../core/jellyfin/models/items.dart';
 import '../../design_tokens/tokens.dart';
 import '../../state/providers.dart';
 import '../../widgets/track_row.dart';
 
+/// Live queue mirror. Watches `playerQueueProvider` (a broadcast stream
+/// on top of `AfPlayerService.queueStream`) so the list reflects the
+/// actual player state — reorder / skip / play-new-album shows up the
+/// moment the player applies it, without snapshotting `DemoLibrary`.
 class QueueScreen extends ConsumerStatefulWidget {
   const QueueScreen({super.key});
 
@@ -15,19 +19,33 @@ class QueueScreen extends ConsumerStatefulWidget {
 }
 
 class _QueueScreenState extends ConsumerState<QueueScreen> {
-  late final List _items;
-
-  @override
-  void initState() {
-    super.initState();
-    final current = ref.read(currentTrackProvider);
-    _items = current == null
-        ? DemoLibrary.tracks.take(10).toList()
-        : [current, ...DemoLibrary.tracks.where((t) => t.id != current.id).take(9)];
-  }
+  /// Local mutable mirror of the player queue — needed because
+  /// `ReorderableListView` requires synchronous list mutation in its
+  /// `onReorder` callback. Refreshed whenever the player emits a new
+  /// queue snapshot.
+  List<AfTrack> _items = const [];
+  List<String> _lastQueueIds = const [];
 
   @override
   Widget build(BuildContext context) {
+    final queueAsync = ref.watch(playerQueueProvider);
+    final current = ref.watch(currentTrackProvider);
+
+    final liveQueue = queueAsync.maybeWhen(
+      data: (q) => q,
+      orElse: () => const <AfTrack>[],
+    );
+
+    // Sync our mutable mirror whenever the player's queue identity
+    // changes (compared as ID sequence so a reorder we just performed
+    // doesn't get clobbered the moment the stream re-emits the new
+    // order back at us).
+    final liveIds = liveQueue.map((t) => t.id).toList(growable: false);
+    if (!_listsMatch(liveIds, _lastQueueIds)) {
+      _items = List<AfTrack>.from(liveQueue);
+      _lastQueueIds = liveIds;
+    }
+
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -49,49 +67,72 @@ class _QueueScreenState extends ConsumerState<QueueScreen> {
         ],
       ),
       body: SafeArea(
-        child: ReorderableListView.builder(
-          padding: const EdgeInsets.symmetric(
-              horizontal: AfSpacing.s16, vertical: AfSpacing.s8),
-          itemCount: _items.length,
-          buildDefaultDragHandles: false,
-          onReorder: (oldIndex, newIndex) {
-            setState(() {
-              if (newIndex > oldIndex) newIndex -= 1;
-              final item = _items.removeAt(oldIndex);
-              _items.insert(newIndex, item);
-            });
-          },
-          itemBuilder: (context, i) {
-            final t = _items[i];
-            final active = i == 0;
-            return Padding(
-              key: ValueKey(t.id),
-              padding: const EdgeInsets.symmetric(vertical: 2),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: TrackRow(
-                      track: t,
-                      density: TrackRowDensity.compact,
-                      isActive: active,
-                      showHeart: false,
-                    ),
+        child: _items.isEmpty
+            ? Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AfSpacing.gutterGenerous,
                   ),
-                  ReorderableDragStartListener(
-                    index: i,
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(
-                          horizontal: AfSpacing.s8),
-                      child: Icon(Icons.drag_indicator_rounded,
-                          color: AfColors.textTertiary),
+                  child: Text(
+                    'Queue is empty. Pick an album or track to start playback.',
+                    style: AfTypography.bodyMedium.copyWith(
+                      color: AfColors.textTertiary,
                     ),
+                    textAlign: TextAlign.center,
                   ),
-                ],
+                ),
+              )
+            : ReorderableListView.builder(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: AfSpacing.s16, vertical: AfSpacing.s8),
+                itemCount: _items.length,
+                buildDefaultDragHandles: false,
+                onReorder: (oldIndex, newIndex) {
+                  setState(() {
+                    if (newIndex > oldIndex) newIndex -= 1;
+                    final item = _items.removeAt(oldIndex);
+                    _items.insert(newIndex, item);
+                  });
+                },
+                itemBuilder: (context, i) {
+                  final t = _items[i];
+                  final active = current?.id == t.id;
+                  return Padding(
+                    key: ValueKey(t.id),
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: TrackRow(
+                            track: t,
+                            density: TrackRowDensity.compact,
+                            isActive: active,
+                            showHeart: false,
+                          ),
+                        ),
+                        ReorderableDragStartListener(
+                          index: i,
+                          child: const Padding(
+                            padding: EdgeInsets.symmetric(
+                                horizontal: AfSpacing.s8),
+                            child: Icon(Icons.drag_indicator_rounded,
+                                color: AfColors.textTertiary),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
               ),
-            );
-          },
-        ),
       ),
     );
+  }
+
+  static bool _listsMatch(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 }

--- a/lib/features/search/search_screen.dart
+++ b/lib/features/search/search_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/demo/demo_library.dart';
 import '../../core/jellyfin/models/items.dart';
 import '../../design_tokens/tokens.dart';
+import '../../state/providers.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/track_row.dart';
 import 'ask_sheet.dart';
@@ -23,33 +23,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   void dispose() {
     _controller.dispose();
     super.dispose();
-  }
-
-  List<AfTrack> get _tracks =>
-      DemoLibrary.tracks.where(_matches).toList();
-  List<AfAlbum> get _albums =>
-      DemoLibrary.albums.where(_matchesAlbum).toList();
-  List<AfArtist> get _artists =>
-      DemoLibrary.artists.where(_matchesArtist).toList();
-
-  bool _matches(AfTrack t) {
-    if (_query.isEmpty) return false;
-    final q = _query.toLowerCase();
-    return t.title.toLowerCase().contains(q) ||
-        t.artistName.toLowerCase().contains(q) ||
-        t.albumName.toLowerCase().contains(q);
-  }
-
-  bool _matchesAlbum(AfAlbum a) {
-    if (_query.isEmpty) return false;
-    final q = _query.toLowerCase();
-    return a.name.toLowerCase().contains(q) ||
-        a.artistName.toLowerCase().contains(q);
-  }
-
-  bool _matchesArtist(AfArtist a) {
-    if (_query.isEmpty) return false;
-    return a.name.toLowerCase().contains(_query.toLowerCase());
   }
 
   @override
@@ -85,11 +58,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                 ? _SearchIdleState(
                     onAskTap: () => AskSheet.show(context),
                   )
-                : _SearchResults(
-                    tracks: _tracks,
-                    albums: _albums,
-                    artists: _artists,
-                  ),
+                : _LiveSearchResults(query: _query),
           ),
         ],
       ),
@@ -97,13 +66,55 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   }
 }
 
-class _SearchIdleState extends StatelessWidget {
+/// Live results panel — watches [searchProvider] so a flick of the
+/// keyboard hits the Jellyfin server (`/Users/{id}/Items?searchTerm=`),
+/// not `DemoLibrary`. Loading state is intentionally blank so the rapid
+/// keystrokes don't trigger a spinner storm; an empty-result state has
+/// its own message.
+class _LiveSearchResults extends ConsumerWidget {
+  final String query;
+  const _LiveSearchResults({required this.query});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(searchProvider(query));
+    return async.maybeWhen(
+      data: (res) => _SearchResults(
+        tracks: res.tracks,
+        albums: res.albums,
+        artists: res.artists,
+      ),
+      error: (e, _) => Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AfSpacing.s16,
+          vertical: AfSpacing.s24,
+        ),
+        child: Text(
+          'Search failed: $e',
+          style: AfTypography.bodySmall.copyWith(
+            color: AfColors.semanticError,
+          ),
+        ),
+      ),
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// Idle (empty query) panel. Genres come from `allGenresProvider` so
+/// signed-in users see their real library, signed-out users see the
+/// demo palette — single source of truth, no duplicated fallback.
+class _SearchIdleState extends ConsumerWidget {
   final VoidCallback onAskTap;
   const _SearchIdleState({required this.onAskTap});
 
   @override
-  Widget build(BuildContext context) {
-    final genres = DemoLibrary.genres;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final genresAsync = ref.watch(allGenresProvider);
+    final genres = genresAsync.maybeWhen(
+      data: (g) => g,
+      orElse: () => const <AfGenre>[],
+    );
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AfSpacing.s16),
       child: ListView(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,10 +21,7 @@ void _boot(String message) {
   print('aetherfin:boot $message');
 }
 
-/// A holder so the OS-integrated audio handler — once initialized — can be
-/// injected into the Riverpod tree. Init runs in the background AFTER the
-/// first frame so the UI is never blocked by audio_service warm-up.
-final _handlerCompleter = Completer<AfPlayerService>();
+
 
 Future<void> main() async {
   _boot('main() entered');
@@ -85,6 +82,14 @@ Future<void> main() async {
       initialAuth = null;
     }
 
+    // Construct THE one and only audio handler up front so the exact
+    // same instance is shared between Riverpod (via
+    // `playerServiceProvider` override) and `AudioService.init` below.
+    // Previously the override created one service and `_warmUpAudio()`
+    // created a second orphaned one — lock-screen controls flapped
+    // against a dead handler and never drove playback.
+    final handler = AfPlayerService();
+
     // Launch the UI immediately — audio init runs in the background AFTER
     // the first frame.
     _boot('calling runApp');
@@ -94,12 +99,12 @@ Future<void> main() async {
           deviceIdProvider.overrideWithValue(deviceId),
           initialAuthProvider.overrideWithValue(initialAuth),
           playerServiceProvider.overrideWith((ref) {
-            // Until AudioService.init resolves, hand out a bare service so
-            // the UI doesn't crash if it reads playerServiceProvider before
-            // the OS-integrated handler is ready.
-            final svc = AfPlayerService();
-            ref.onDispose(svc.dispose);
-            return svc;
+            // Apply the same Riverpod-side wiring the default factory
+            // would have applied (currentTrack forwarding + Jellyfin
+            // session reporter), but on the singleton `handler` so the
+            // OS-integrated handler IS the one the UI sees.
+            wirePlayerService(ref, handler);
+            return handler;
           }),
         ],
         child: const AetherfinApp(),
@@ -113,7 +118,7 @@ Future<void> main() async {
     // works without lock-screen controls.
     SchedulerBinding.instance.addPostFrameCallback((_) {
       _boot('first frame painted — kicking AudioService init');
-      unawaited(_warmUpAudio());
+      unawaited(_warmUpAudio(handler));
     });
   }, (error, stack) {
     // ignore: avoid_print
@@ -123,10 +128,9 @@ Future<void> main() async {
   });
 }
 
-Future<void> _warmUpAudio() async {
+Future<void> _warmUpAudio(AfPlayerService handler) async {
   try {
     _boot('AudioService.init starting');
-    final handler = AfPlayerService();
     await AudioService.init(
       builder: () => handler,
       config: const AudioServiceConfig(
@@ -138,9 +142,6 @@ Future<void> _warmUpAudio() async {
       ),
     );
     _boot('AudioService.init OK');
-    if (!_handlerCompleter.isCompleted) {
-      _handlerCompleter.complete(handler);
-    }
   } catch (e, stack) {
     // ignore: avoid_print
     print('aetherfin:error AudioService.init failed: $e');

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../core/audio/jellyfin_playback_reporter.dart';
 import '../core/audio/player_service.dart';
 import '../core/audio/spectral_extractor.dart';
 import '../core/demo/demo_library.dart';
@@ -7,7 +8,25 @@ import '../core/jellyfin/auth_storage.dart';
 import '../core/jellyfin/client.dart';
 import '../core/jellyfin/models/items.dart';
 import '../core/jellyfin/models/server.dart';
+import '../core/lyrics/lrc_parser.dart';
 import '../design_tokens/colors.dart';
+
+/// Compact one-liner for the `aetherfin:data` trace category.
+///
+/// Every place that resolves data the UI will render goes through this
+/// helper so an `adb logcat -s flutter | grep aetherfin:data` output
+/// shows exactly which feature served live Jellyfin data vs. demo data
+/// vs. still-mocked data. Used by reviewers to spot regressions where a
+/// screen silently slips back onto `DemoLibrary` after sign-in.
+void _logData(
+  String feature, {
+  required String source,
+  String? extra,
+}) {
+  final detail = extra == null || extra.isEmpty ? '' : ' $extra';
+  // ignore: avoid_print
+  print('aetherfin:data $feature source=$source$detail');
+}
 
 /// ─────────────────────────────────────────────────────────────────────────
 /// Auth
@@ -68,7 +87,13 @@ class AuthNotifier extends StateNotifier<JellyfinAuth?> {
 
 final jellyfinClientProvider = Provider<JellyfinClient?>((ref) {
   final auth = ref.watch(authProvider);
-  if (auth == null) return null;
+  if (auth == null) {
+    _logData('jellyfinClient', source: 'demo', extra: '(signed out)');
+    return null;
+  }
+  _logData('jellyfinClient',
+      source: 'live',
+      extra: 'server=${auth.server.baseUrl} user=${auth.userName}');
   return JellyfinClient(
     server: auth.server,
     deviceId: ref.watch(deviceIdProvider),
@@ -81,10 +106,51 @@ final jellyfinClientProvider = Provider<JellyfinClient?>((ref) {
 /// Audio player (singleton handler)
 /// ─────────────────────────────────────────────────────────────────────────
 
+/// Wires Riverpod-side side-effects onto an [AfPlayerService] instance:
+///   1. Forwards `onTrackChanged` to `currentTrackProvider` so the UI
+///      re-renders on queue advance / manual skip / lock-screen action.
+///   2. Instantiates the [JellyfinPlaybackReporter] (Sessions/Playing*
+///      lifecycle) bound to the same service.
+///   3. Registers disposal so both the reporter and the service shut
+///      down when the ProviderScope is torn down.
+///
+/// Pulled out as a free function so `main.dart` can hand the *same*
+/// service instance to `AudioService.init` (for lock-screen controls)
+/// and to the provider tree — without duplicating the wiring logic
+/// across the default factory and the override.
+void wirePlayerService(Ref ref, AfPlayerService svc) {
+  svc.onTrackChanged = (track) {
+    ref.read(currentTrackProvider.notifier).state = track;
+  };
+  final reporter = JellyfinPlaybackReporter(
+    svc,
+    () => ref.read(jellyfinClientProvider),
+  );
+  ref.onDispose(() async {
+    await reporter.dispose();
+    await svc.dispose();
+  });
+}
+
 final playerServiceProvider = Provider<AfPlayerService>((ref) {
   final svc = AfPlayerService();
-  ref.onDispose(svc.dispose);
+  wirePlayerService(ref, svc);
   return svc;
+});
+
+/// Live queue exposed by the player. The Queue screen watches this so
+/// reorder / skip / play-new-album immediately re-render — no more
+/// snapshotting `DemoLibrary.tracks` into local state.
+final playerQueueProvider = StreamProvider.autoDispose<List<AfTrack>>((ref) {
+  final svc = ref.watch(playerServiceProvider);
+  // ignore: avoid_print
+  // Emit the current snapshot first so a freshly mounted Queue screen
+  // doesn't render an empty list while waiting for the next stream tick.
+  return Stream<List<AfTrack>>.multi((controller) {
+    controller.add(svc.currentQueue);
+    final sub = svc.queueStream.listen(controller.add);
+    controller.onCancel = sub.cancel;
+  });
 });
 
 /// Stream of position from the single player. Per non-negotiable §4.3,
@@ -146,29 +212,52 @@ final currentSpectralProvider = Provider<Spectral>((ref) {
 final recentlyAddedAlbumsProvider =
     FutureProvider.autoDispose<List<AfAlbum>>((ref) async {
   final client = ref.watch(jellyfinClientProvider);
-  if (client == null) return DemoLibrary.albums;
-  return client.recentlyAddedAlbums();
+  if (client == null) {
+    _logData('recentlyAddedAlbums',
+        source: 'demo', extra: '(signed out)');
+    return DemoLibrary.albums;
+  }
+  final res = await client.recentlyAddedAlbums();
+  _logData('recentlyAddedAlbums', source: 'live', extra: 'count=${res.length}');
+  return res;
 });
 
 final recentlyPlayedTracksProvider =
     FutureProvider.autoDispose<List<AfTrack>>((ref) async {
   final client = ref.watch(jellyfinClientProvider);
-  if (client == null) return DemoLibrary.tracks.take(10).toList();
-  return client.recentlyPlayed();
+  if (client == null) {
+    _logData('recentlyPlayedTracks',
+        source: 'demo', extra: '(signed out)');
+    return DemoLibrary.tracks.take(10).toList();
+  }
+  final res = await client.recentlyPlayed();
+  _logData('recentlyPlayedTracks',
+      source: 'live', extra: 'count=${res.length}');
+  return res;
 });
 
 final allArtistsProvider =
     FutureProvider.autoDispose<List<AfArtist>>((ref) async {
   final client = ref.watch(jellyfinClientProvider);
-  if (client == null) return DemoLibrary.artists;
-  return client.artists();
+  if (client == null) {
+    _logData('allArtists', source: 'demo', extra: '(signed out)');
+    return DemoLibrary.artists;
+  }
+  final res = await client.artists();
+  _logData('allArtists', source: 'live', extra: 'count=${res.length}');
+  return res;
 });
 
 final allPlaylistsProvider =
     FutureProvider.autoDispose<List<AfPlaylist>>((ref) async {
   final client = ref.watch(jellyfinClientProvider);
-  if (client == null) return DemoLibrary.playlists;
-  return client.playlists();
+  if (client == null) {
+    _logData('allPlaylists', source: 'demo', extra: '(signed out)');
+    return DemoLibrary.playlists;
+  }
+  final res = await client.playlists();
+  _logData('allPlaylists', source: 'live', extra: 'count=${res.length}');
+  return res;
 });
 
 /// Music genres. Jellyfin returns these without colors so we cycle through
@@ -176,18 +265,34 @@ final allPlaylistsProvider =
 final allGenresProvider =
     FutureProvider.autoDispose<List<AfGenre>>((ref) async {
   final client = ref.watch(jellyfinClientProvider);
-  if (client == null) return DemoLibrary.genres;
-  return client.genres();
+  if (client == null) {
+    _logData('allGenres', source: 'demo', extra: '(signed out)');
+    return DemoLibrary.genres;
+  }
+  final res = await client.genres();
+  _logData('allGenres', source: 'live', extra: 'count=${res.length}');
+  return res;
 });
 
 final albumDetailProvider = FutureProvider.autoDispose
     .family<({AfAlbum album, List<AfTrack> tracks})?, String>((ref, id) async {
   final client = ref.watch(jellyfinClientProvider);
   if (client != null) {
-    return client.album(id);
+    final res = await client.album(id);
+    _logData('albumDetail',
+        source: 'live',
+        extra: 'id=$id tracks=${res?.tracks.length ?? 0}');
+    return res;
   }
   final album = DemoLibrary.albumById(id);
-  if (album == null) return null;
+  if (album == null) {
+    _logData('albumDetail',
+        source: 'demo', extra: 'id=$id (not found)');
+    return null;
+  }
+  _logData('albumDetail',
+      source: 'demo',
+      extra: 'id=$id tracks=${DemoLibrary.tracksByAlbum(id).length}');
   return (album: album, tracks: DemoLibrary.tracksByAlbum(id));
 });
 
@@ -195,9 +300,143 @@ final artistDetailProvider =
     FutureProvider.autoDispose.family<AfArtist?, String>((ref, id) async {
   final client = ref.watch(jellyfinClientProvider);
   if (client != null) {
-    return client.artist(id);
+    final res = await client.artist(id);
+    _logData('artistDetail',
+        source: 'live', extra: 'id=$id found=${res != null}');
+    return res;
   }
-  return DemoLibrary.artistById(id);
+  final res = DemoLibrary.artistById(id);
+  _logData('artistDetail',
+      source: 'demo', extra: 'id=$id found=${res != null}');
+  return res;
+});
+
+/// Albums credited to a given artist. Used by the Artist screen's albums
+/// rail — replaces the previous DemoLibrary `.where(byName)` filter
+/// (which only ever showed demo albums even when signed in).
+final artistAlbumsProvider = FutureProvider.autoDispose
+    .family<List<AfAlbum>, String>((ref, artistId) async {
+  final client = ref.watch(jellyfinClientProvider);
+  if (client == null) {
+    final artist = DemoLibrary.artistById(artistId);
+    final res = artist == null
+        ? const <AfAlbum>[]
+        : DemoLibrary.albums.where((a) => a.artistName == artist.name).toList();
+    _logData('artistAlbums',
+        source: 'demo', extra: 'artistId=$artistId count=${res.length}');
+    return res;
+  }
+  final res = await client.artistAlbums(artistId);
+  _logData('artistAlbums',
+      source: 'live', extra: 'artistId=$artistId count=${res.length}');
+  return res;
+});
+
+/// Top tracks for an artist (highest play count, falling back to
+/// alphabetical on fresh libraries). Replaces the previous DemoLibrary
+/// `.where(byName).take(5)` filter on the Artist screen.
+final artistTopTracksProvider = FutureProvider.autoDispose
+    .family<List<AfTrack>, String>((ref, artistId) async {
+  final client = ref.watch(jellyfinClientProvider);
+  if (client == null) {
+    final artist = DemoLibrary.artistById(artistId);
+    final res = artist == null
+        ? const <AfTrack>[]
+        : DemoLibrary.tracks
+            .where((t) => t.artistName == artist.name)
+            .take(5)
+            .toList();
+    _logData('artistTopTracks',
+        source: 'demo', extra: 'artistId=$artistId count=${res.length}');
+    return res;
+  }
+  final res = await client.artistTopTracks(artistId, limit: 5);
+  _logData('artistTopTracks',
+      source: 'live', extra: 'artistId=$artistId count=${res.length}');
+  return res;
+});
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// Search & lyrics (live)
+/// ─────────────────────────────────────────────────────────────────────────
+
+/// Server-side search results. Hits `/Users/{id}/Items?searchTerm=`
+/// (NOT `/Search/Hints` — see CLAUDE.md §10 footgun #3) and bucketises
+/// the BaseItemDto stream into tracks/albums/artists for the screen.
+typedef SearchResults = ({
+  List<AfTrack> tracks,
+  List<AfAlbum> albums,
+  List<AfArtist> artists,
+});
+
+final searchProvider = FutureProvider.autoDispose
+    .family<SearchResults, String>((ref, raw) async {
+  final query = raw.trim();
+  if (query.isEmpty) {
+    _logData('search', source: 'live', extra: 'query="" (empty)');
+    return (
+      tracks: const <AfTrack>[],
+      albums: const <AfAlbum>[],
+      artists: const <AfArtist>[],
+    );
+  }
+  final client = ref.watch(jellyfinClientProvider);
+  if (client == null) {
+    final tracks = DemoLibrary.tracks
+        .where((t) =>
+            t.title.toLowerCase().contains(query.toLowerCase()) ||
+            t.artistName.toLowerCase().contains(query.toLowerCase()) ||
+            t.albumName.toLowerCase().contains(query.toLowerCase()))
+        .toList(growable: false);
+    final albums = DemoLibrary.albums
+        .where((a) =>
+            a.name.toLowerCase().contains(query.toLowerCase()) ||
+            a.artistName.toLowerCase().contains(query.toLowerCase()))
+        .toList(growable: false);
+    final artists = DemoLibrary.artists
+        .where((a) => a.name.toLowerCase().contains(query.toLowerCase()))
+        .toList(growable: false);
+    _logData('search',
+        source: 'demo',
+        extra: 'query="$query" tracks=${tracks.length} '
+            'albums=${albums.length} artists=${artists.length}');
+    return (tracks: tracks, albums: albums, artists: artists);
+  }
+  final res = await client.search(query);
+  _logData('search',
+      source: 'live',
+      extra: 'query="$query" tracks=${res.tracks.length} '
+          'albums=${res.albums.length} artists=${res.artists.length}');
+  return (
+    tracks: res.tracks,
+    albums: res.albums,
+    artists: res.artists,
+  );
+});
+
+/// Time-synced lyrics for a track. Returns `null` when the server has
+/// none and the UI should render the "no lyrics" empty state. Parses
+/// the raw LRC payload from `/Audio/{id}/Lyrics` into our [Lrc] type so
+/// the screen doesn't have to know about LRC syntax.
+final lyricsProvider =
+    FutureProvider.autoDispose.family<Lrc?, String>((ref, trackId) async {
+  final client = ref.watch(jellyfinClientProvider);
+  if (client == null) {
+    _logData('lyrics',
+        source: 'demo', extra: 'trackId=$trackId (signed out)');
+    return null;
+  }
+  final raw = await client.lyrics(trackId);
+  if (raw == null || raw.isEmpty) {
+    _logData('lyrics',
+        source: 'live', extra: 'trackId=$trackId result=none');
+    return null;
+  }
+  final parsed = parseLrc(raw);
+  _logData('lyrics',
+      source: 'live',
+      extra: 'trackId=$trackId lines=${parsed.lines.length}');
+  return parsed;
 });
 
 /// ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces every remaining `DemoLibrary` reference on signed-in screens with real Jellyfin HTTP calls, closes the playback-session reporting gap, and adds a new structured log category so the user can see in `adb logcat -s flutter` exactly which feature is on live vs demo vs mock data.

### What's live now (was mock/demo before)

| Screen | Before | After |
|---|---|---|
| Search | filtered `DemoLibrary.tracks/albums/artists` in the widget | `searchProvider` → `client.search()` → `GET /Users/{id}/Items?searchTerm=…` (NOT `/Search/Hints` per CLAUDE.md §10 #3); genres pulled from `allGenresProvider` instead of `DemoLibrary.genres` |
| Lyrics | hardcoded `_demoLrc` constant | `lyricsProvider` → `client.lyrics(trackId)` → `GET /Audio/{id}/Lyrics` + LRC parse; empty-state UI when server returns none |
| Queue | seeded from `DemoLibrary.tracks` on mount | `playerQueueProvider` (Stream on top of `AfPlayerService.queueStream`); reflects real player state instantly |
| Artist | `DemoLibrary.albums.where(…)` / `tracks.where(…)` filters | `artistAlbumsProvider` (`/Items?AlbumArtistIds=…`) + `artistTopTracksProvider` (`/Items?ArtistIds=…&SortBy=PlayCount`) |

### Playback session reporting (was missing entirely)

- New `JellyfinPlaybackReporter` subscribed to `AfPlayerService` streams.
  - `POST /Sessions/Playing` on track start
  - `POST /Sessions/Playing/Progress` every 10s + on pause/resume
  - `POST /Sessions/Playing/Stopped` on track-advance, player stop, dispose
- Lazy `clientGetter` so the reporter automatically targets the new server when auth flips.
- Wired via `wirePlayerService()` in `lib/state/providers.dart`.

### `aetherfin:data` log category

Every Riverpod data fetch now emits one line:

```
aetherfin:data <feature> source=<live|demo|mock> <details>
```

Examples in `adb logcat -s flutter`:

```
aetherfin:data jellyfinClient source=live server=http://srv user=azrim
aetherfin:data recentlyAddedAlbums source=live count=20
aetherfin:data search source=live query="bicep" tracks=6 albums=2 artists=1
aetherfin:data lyrics source=live trackId=abc lines=42
aetherfin:data currentTrack source=live id=abc title="Atlas" index=3
aetherfin:data playbackStart source=live trackId=abc
aetherfin:data playbackProgress source=live trackId=abc pos=10000ms paused=false
aetherfin:data playbackStop source=live trackId=abc pos=215000ms
```

So you can scroll the app, watch logcat, and immediately see any screen that's still on demo data after sign-in (none should be).

### Audio-handler singleton fix (latent bug)

Previously `main.dart`'s `playerServiceProvider` override created one `AfPlayerService` and `_warmUpAudio()` created a second one for `AudioService.init`. The OS-integrated handler was orphaned — lock-screen controls drove a dead service. Now there's exactly one `handler` constructed in `main()` and shared between both, via the new `wirePlayerService(Ref, AfPlayerService)` helper.

### Other cleanup

- Drop dead `JellyfinAuth.authHeader` getter (CLAUDE.md §10 footgun #2 — it hard-coded `DeviceId="aetherfin-android"`).
- Tighten `client.reportProgress()` with `_assertUser()` + add `PlayMethod=DirectStream`.
- Document the new log category in `CLAUDE.md §7`.

## Review & Testing Checklist for Human

- [ ] Run on a real device against your Jellyfin server. `adb logcat -s flutter | grep aetherfin:data` should show **only** `source=live` on every signed-in screen (search, lyrics, queue, artist, home, library). `source=demo` should appear only on the onboarding preview before sign-in.
- [ ] Start a track, watch logcat for `aetherfin:data playbackStart`, then `…playbackProgress` every ~10s, and `…playbackStop` when you skip / stop. Open Jellyfin's Dashboard → "Now Playing" while testing — your username + track should appear.
- [ ] Skip to next track in the queue: `currentTrack source=live id=… index=…` should fire, and the Now Playing / mini-player / lyrics screen should re-render. (Before this PR, `currentTrackProvider` never advanced.)
- [ ] Lock-screen / notification controls: pause / next / previous should actually drive playback. (Fixes the orphaned-handler bug.)
- [ ] Search screen: type a query — should hit your server, not show DemoLibrary content. Empty query should still show the Genres grid from `/MusicGenres`.

### Test plan

1. `flutter pub get && flutter analyze --no-fatal-infos && flutter test` → 0 errors, 0 warnings, all 6 tests pass (verified locally).
2. `flutter run --debug` against your Jellyfin server, sign in.
3. `adb logcat -c && adb logcat -s flutter` in a parallel terminal.
4. Walk through each screen, watch the `aetherfin:data` lines flip to `source=live`.

### Notes

- No json_serializable used; all new models hand-written.
- No new HTTP clients; only `JellyfinClient` speaks HTTP (CLAUDE.md §8).
- All providers are `FutureProvider.autoDispose` or `StreamProvider.autoDispose` — no `ChangeNotifier`.
- `DemoLibrary` is now reachable only via the signed-out fallback path inside providers; no live screen references it directly.