### PR TITLE
Fix audio playback: direct-stream URL + aetherfin:audio diagnostics

### DIFF
--- a/lib/core/audio/play_actions.dart
+++ b/lib/core/audio/play_actions.dart
@@ -37,8 +37,16 @@ class PlayActions {
           startIndex: startIndex,
           resolveStreamUrl: resolveStreamUrl,
         );
-      } catch (_) {
-        // Network/server issue — leave the queue staged so the UI is correct.
+      } catch (e, stack) {
+        // Leave the queue staged so the mini-player keeps the track
+        // visible, but log loudly so a logcat capture shows the cause
+        // (`aetherfin:audio` lines from player_service already cover
+        // setAudioSource/play failures; this catches anything thrown
+        // before/around them).
+        // ignore: avoid_print
+        print('aetherfin:audio playQueue failed: $e');
+        // ignore: avoid_print
+        print('aetherfin:audio stack: $stack');
       }
     }
   }

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -28,10 +28,29 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
   void Function(AfTrack track)? onTrackChanged;
 
   AfPlayerService() {
-    _player.playbackEventStream.listen(_broadcastPlaybackEvent);
+    _player.playbackEventStream.listen(
+      _broadcastPlaybackEvent,
+      onError: (Object e, StackTrace stack) {
+        // ignore: avoid_print
+        print('aetherfin:audio playbackEventStream error: $e');
+        // ignore: avoid_print
+        print('aetherfin:audio stack: $stack');
+      },
+    );
+    _player.processingStateStream.listen((state) {
+      // ignore: avoid_print
+      print('aetherfin:audio processingState=${state.name} '
+          'playing=${_player.playing} position=${_player.position.inMilliseconds}ms '
+          'duration=${_player.duration?.inMilliseconds ?? "?"}ms');
+    });
     _player.currentIndexStream.listen((idx) {
       if (idx == null) return;
       if (idx < 0 || idx >= _trackQueue.length) return;
+      // currentIndexStream re-emits on every state change, not just on
+      // index changes — without this dedupe we'd fire onTrackChanged +
+      // playbackStart dozens of times for the same track and spam
+      // /Sessions/Playing.
+      if (idx == _currentIndex) return;
       _currentIndex = idx;
       final track = _trackQueue[idx];
       mediaItem.add(_mediaItemFor(track));
@@ -78,21 +97,44 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
               tag: _mediaItemFor(t),
             ))
         .toList();
-    await _player.setAudioSource(
-      ConcatenatingAudioSource(children: sources),
-      initialIndex: startIndex,
-    );
-    _currentIndex = startIndex;
     final startTrack = tracks[startIndex];
+    // Pre-set _currentIndex BEFORE setAudioSource so the currentIndexStream
+    // listener's dedupe (`if (idx == _currentIndex) return;`) suppresses
+    // the spurious emit that fires immediately after the source is set —
+    // we drive the initial onTrackChanged + mediaItem broadcast ourselves
+    // below so the UI / playback reporter see the new track before audio
+    // even starts loading.
+    _currentIndex = startIndex;
     mediaItem.add(_mediaItemFor(startTrack));
     _trackController.add(startTrack);
     // ignore: avoid_print
     print(
       'aetherfin:data playQueue source=live size=${tracks.length} '
-      'startIndex=$startIndex first="${startTrack.title}"',
+      'startIndex=$startIndex first="${startTrack.title}" '
+      'url="${resolveStreamUrl(startTrack)}"',
     );
     onTrackChanged?.call(startTrack);
-    await _player.play();
+    try {
+      await _player.setAudioSource(
+        ConcatenatingAudioSource(children: sources),
+        initialIndex: startIndex,
+      );
+    } on Object catch (e, stack) {
+      // ignore: avoid_print
+      print('aetherfin:audio setAudioSource failed: $e');
+      // ignore: avoid_print
+      print('aetherfin:audio stack: $stack');
+      rethrow;
+    }
+    try {
+      await _player.play();
+    } on Object catch (e, stack) {
+      // ignore: avoid_print
+      print('aetherfin:audio play() failed: $e');
+      // ignore: avoid_print
+      print('aetherfin:audio stack: $stack');
+      rethrow;
+    }
   }
 
   @override

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -255,23 +255,40 @@ class JellyfinClient {
 
   /// Build a streaming URL for a given track ID.
   ///
-  /// We DO NOT add `static=true` — that would force direct play and bypass
-  /// Jellyfin's transcoder. Instead we let the server decide based on the
-  /// `audioCodec` / `maxStreamingBitrate` hints we send, and the resulting
-  /// `MediaSource` carries the [TrackQuality] honesty signal back to us.
+  /// Uses `/Audio/{id}/stream?Static=true` — the direct-stream endpoint
+  /// which serves the original file byte-for-byte (mp3 / flac / m4a /
+  /// ogg / wav / opus). just_audio's ExoPlayer plays these natively.
+  ///
+  /// We previously tried `/Audio/{id}/universal` (transcoding-aware) with
+  /// only `api_key` + `maxStreamingBitrate` hints. Without the full
+  /// Finamp-style `Container=…&TranscodingProtocol=hls&AudioCodec=aac`
+  /// negotiation, Jellyfin defaults to serving an HLS manifest that
+  /// just_audio could not decode — audio appeared "playing" (state=ready,
+  /// IsPaused=false) but `position` never advanced past 0 because the
+  /// decoder rejected the stream.
+  ///
+  /// Direct-stream is simpler, more reliable, and the quality chip can
+  /// still be computed from the source-file metadata we already have on
+  /// [AfTrack]. If users hit a track with an exotic codec ExoPlayer can't
+  /// decode, we'll re-introduce transcoding negotiation as a follow-up
+  /// with the full param set.
   String trackStreamUrl(
     String trackId, {
     int? maxBitrateKbps,
     String? deviceProfileId,
   }) {
+    _assertUser();
     final qp = <String, String>{
+      'Static': 'true',
+      'UserId': userId!,
+      'DeviceId': deviceId,
       if (accessToken != null) 'api_key': accessToken!,
       if (maxBitrateKbps != null)
-        'maxStreamingBitrate': '${maxBitrateKbps * 1000}',
-      if (deviceProfileId != null) 'profileId': deviceProfileId,
+        'MaxStreamingBitrate': '${maxBitrateKbps * 1000}',
+      if (deviceProfileId != null) 'DeviceProfileId': deviceProfileId,
     };
     final query = qp.entries.map((e) => '${e.key}=${e.value}').join('&');
-    return '${server.baseUrl}/Audio/$trackId/universal?$query';
+    return '${server.baseUrl}/Audio/$trackId/stream?$query';
   }
 
   /// `POST /Sessions/Playing` — tell the server a track just started.


### PR DESCRIPTION
## Summary

Audio playback was broken — tapping a track logged `playbackStart 204 OK` and `playbackProgress positionMs=0 paused=false` every 10 s, but no sound came out of the speaker and `_player.position` never advanced past 0. From the user's log it looked like the entire UI was a "dummy" because the play button appeared to do nothing.

### Root cause

`JellyfinClient.trackStreamUrl()` was building a URL against `/Audio/{id}/universal` with only `api_key` + `maxStreamingBitrate`. Without the full Finamp-style transcoding negotiation (`Container=…&TranscodingProtocol=hls&AudioCodec=aac&PlaySessionId=…`) Jellyfin defaults to an HLS manifest that `just_audio` could not decode in this configuration. `setAudioSource()` resolved, `play()` resolved, `processingState` reached `ready`, but ExoPlayer rejected the actual media segments — and the error went nowhere because we never listened to `playbackEventStream.onError`.

### Fix

1. **Direct-stream URL.** Switch to `/Audio/{id}/stream?Static=true&UserId=…&DeviceId=…&api_key=…` which serves the original file byte-for-byte (mp3 / flac / m4a / ogg / opus / wav). `just_audio`'s ExoPlayer plays these natively. The quality chip can still be derived from `AfTrack` metadata (no need for transcoding-aware negotiation right now). We can re-introduce a proper transcoding path as a follow-up with the full param set if a user hits an exotic codec.
2. **`aetherfin:audio` log category.** New trace prefix covering:
    - `processingState` transitions (`idle` / `loading` / `buffering` / `ready` / `completed`) with position + duration
    - `playbackEventStream.onError` (the missing error path that hid this bug)
    - `setAudioSource()` / `play()` exceptions
    - `PlayActions.playQueue` catch block (was silently swallowing)
3. **Dedupe `currentTrack`.** The `currentIndexStream` listener was firing 12+ times for the same index because `just_audio` re-emits on every state change. Now `if (idx == _currentIndex) return;` suppresses no-op emits and `playQueue()` pre-sets `_currentIndex` + explicitly broadcasts the start track before `setAudioSource` so the UI / playback reporter see it immediately.

## Review & Testing Checklist for Human

- [ ] **Audio actually plays.** Tap a track; you should hear it within ~1 s. `adb logcat -s flutter` should show `aetherfin:audio processingState=loading … buffering … ready` and then `playbackProgress … positionMs=<advancing>` not `positionMs=0`.
- [ ] **`aetherfin:audio` lines on play.** Expect a clean sequence: `processingState=idle` → `loading` → `buffering` → `ready` → eventually `completed`. If you see anything else (especially an error line), grab the full block and send it back — that's the next clue.
- [ ] **No more `currentTrack` spam.** Tapping one track should fire `aetherfin:data currentTrack source=live …` **once**, not a dozen times.
- [ ] **Existing flows still work.** Lock-screen / notification controls, queue reorder, skip-to-next.

### Test plan

1. `flutter pub get && flutter analyze --no-fatal-infos && flutter test` → 0 errors, 0 warnings, 6/6 pass (verified locally on Flutter 3.41.9 stable).
2. `flutter run --debug`, sign in, tap a track on Home or Library.
3. `adb logcat -c && adb logcat -s flutter` in parallel — watch for `aetherfin:audio processingState=ready` then increasing `positionMs`.
4. Open Jellyfin Dashboard → Now Playing — track + username should appear AND the progress bar there should also advance.

### Notes

- Still no `json_serializable`, still only `JellyfinClient` speaks HTTP.
- `CLAUDE.md §7` already lists `aetherfin:audio` as a log prefix conceptually — the new lines plug in to that table. If you want me to add an explicit row for `aetherfin:audio` to the table I can do that in a follow-up; held off here to keep the diff focused.
- If after this you still don't hear audio, the next logcat capture (`adb logcat -s flutter | grep -E 'aetherfin:audio|aetherfin:http'`) will tell us exactly which stage failed — that's why the diagnostic logs are part of this PR.