### PR TITLE
Wire dead Now Playing / Album / Library buttons

### DIFF
--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -73,12 +73,21 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
   /// Broadcast stream of the active queue — emits the same list shape the
   /// Queue screen renders so it reflects skips / replacements immediately.
   Stream<List<AfTrack>> get queueStream => _queueController.stream;
+  /// Broadcast stream of just_audio's shuffle flag.
+  Stream<bool> get shuffleModeStream => _player.shuffleModeEnabledStream;
+  /// Broadcast stream of just_audio's loop mode (off / one / all).
+  Stream<LoopMode> get loopModeStream => _player.loopModeStream;
+  /// Broadcast stream of the playback speed multiplier (1.0 = normal).
+  Stream<double> get speedStream => _player.speedStream;
   Duration get position => _player.position;
   List<AfTrack> get currentQueue => List.unmodifiable(_trackQueue);
   AfTrack? get currentTrack =>
       (_currentIndex >= 0 && _currentIndex < _trackQueue.length)
           ? _trackQueue[_currentIndex]
           : null;
+  bool get isShuffleEnabled => _player.shuffleModeEnabled;
+  LoopMode get loopMode => _player.loopMode;
+  double get speed => _player.speed;
 
   /// Replace the queue with [tracks] and start playback at [startIndex].
   Future<void> playQueue(
@@ -159,6 +168,42 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
   @override
   Future<void> skipToQueueItem(int index) =>
       _player.seek(Duration.zero, index: index);
+
+  /// Toggle shuffle. just_audio reshuffles the queue order; the
+  /// underlying [_trackQueue] list is left in original order — only the
+  /// playback order changes. The Queue screen reflects the new order via
+  /// `queueStream` (currentIndexStream still fires per-skip).
+  ///
+  /// Named with the `af` prefix to avoid colliding with
+  /// `BaseAudioHandler.setShuffleMode(AudioServiceShuffleMode)` which the
+  /// OS lock-screen calls with a different enum type.
+  Future<void> setAfShuffleMode(bool enabled) async {
+    if (enabled) {
+      // Generate a fresh shuffle order so consecutive toggles don't
+      // produce the same sequence.
+      await _player.shuffle();
+    }
+    await _player.setShuffleModeEnabled(enabled);
+    // ignore: avoid_print
+    print('aetherfin:data shuffleMode source=live enabled=$enabled');
+  }
+
+  /// Set loop mode to `off`, `one`, or `all`.
+  ///
+  /// Named with the `af` prefix to avoid colliding with
+  /// `BaseAudioHandler.setRepeatMode(AudioServiceRepeatMode)`.
+  Future<void> setAfLoopMode(LoopMode mode) async {
+    await _player.setLoopMode(mode);
+    // ignore: avoid_print
+    print('aetherfin:data loopMode source=live mode=${mode.name}');
+  }
+
+  /// Set playback speed multiplier (0.5–2.0 is the user-facing range).
+  Future<void> setAfSpeed(double speed) async {
+    await _player.setSpeed(speed);
+    // ignore: avoid_print
+    print('aetherfin:data playbackSpeed source=live speed=$speed');
+  }
 
   Future<void> dispose() async {
     await _player.dispose();

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -350,6 +350,22 @@ class JellyfinClient {
     );
   }
 
+  /// Toggle a library item's favorite state.
+  ///
+  /// `POST /Users/{userId}/FavoriteItems/{itemId}` adds, the matching
+  /// DELETE removes. Both endpoints return the updated `UserItemDataDto`
+  /// — we don't need the body, the boolean state in the request is the
+  /// source of truth and the UI updates optimistically.
+  Future<void> setFavorite(String itemId, bool isFavorite) async {
+    _assertUser();
+    final path = 'Users/$userId/FavoriteItems/$itemId';
+    if (isFavorite) {
+      await _dio.post<Map<String, dynamic>>(path);
+    } else {
+      await _dio.delete<Map<String, dynamic>>(path);
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Library endpoints
   // ---------------------------------------------------------------------------

--- a/lib/features/album/album_screen.dart
+++ b/lib/features/album/album_screen.dart
@@ -138,6 +138,7 @@ class _AlbumScreenState extends ConsumerState<AlbumScreen> {
                           ),
                           const SizedBox(height: AfSpacing.s16),
                           _ActionRow(
+                            albumId: widget.albumId,
                             onPlay: () => ref
                                 .read(playActionsProvider)
                                 .playAlbum(tracks),
@@ -223,7 +224,12 @@ class _OpacityAppBar extends StatelessWidget {
             ),
             IconButton(
               icon: const Icon(Icons.more_vert_rounded),
-              onPressed: () {},
+              onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('More options coming soon'),
+                  duration: Duration(seconds: 2),
+                ),
+              ),
             ),
           ],
         ),
@@ -232,9 +238,45 @@ class _OpacityAppBar extends StatelessWidget {
   }
 }
 
-class _ActionRow extends StatelessWidget {
+class _ActionRow extends ConsumerStatefulWidget {
   final VoidCallback onPlay;
-  const _ActionRow({required this.onPlay});
+  final String albumId;
+  const _ActionRow({required this.onPlay, required this.albumId});
+
+  @override
+  ConsumerState<_ActionRow> createState() => _ActionRowState();
+}
+
+class _ActionRowState extends ConsumerState<_ActionRow> {
+  bool _isFavorite = false;
+  bool _favoriteBusy = false;
+
+  Future<void> _toggleFavorite() async {
+    if (_favoriteBusy) return;
+    final client = ref.read(jellyfinClientProvider);
+    if (client == null) return;
+    setState(() {
+      _favoriteBusy = true;
+      _isFavorite = !_isFavorite;
+    });
+    try {
+      await client.setFavorite(widget.albumId, _isFavorite);
+      // ignore: avoid_print
+      print(
+        'aetherfin:data albumFavorite source=live '
+        'id=${widget.albumId} isFavorite=$_isFavorite',
+      );
+    } catch (e) {
+      setState(() => _isFavorite = !_isFavorite);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not update favorite: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _favoriteBusy = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -242,17 +284,37 @@ class _ActionRow extends StatelessWidget {
       children: [
         Expanded(
           child: ElevatedButton.icon(
-            onPressed: onPlay,
+            onPressed: widget.onPlay,
             icon: const Icon(Icons.play_arrow_rounded),
             label: const Text('Play'),
           ),
         ),
         const SizedBox(width: AfSpacing.s12),
-        _IconCircle(icon: Icons.favorite_border, onTap: () {}),
+        _IconCircle(
+          icon: _isFavorite ? Icons.favorite : Icons.favorite_border,
+          color: _isFavorite ? AfColors.semanticError : null,
+          onTap: _toggleFavorite,
+        ),
         const SizedBox(width: AfSpacing.s8),
-        _IconCircle(icon: Icons.download_outlined, onTap: () {}),
+        _IconCircle(
+          icon: Icons.download_outlined,
+          onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Offline downloads coming soon'),
+              duration: Duration(seconds: 2),
+            ),
+          ),
+        ),
         const SizedBox(width: AfSpacing.s8),
-        _IconCircle(icon: Icons.more_horiz_rounded, onTap: () {}),
+        _IconCircle(
+          icon: Icons.more_horiz_rounded,
+          onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('More options coming soon'),
+              duration: Duration(seconds: 2),
+            ),
+          ),
+        ),
       ],
     );
   }
@@ -261,7 +323,8 @@ class _ActionRow extends StatelessWidget {
 class _IconCircle extends StatelessWidget {
   final IconData icon;
   final VoidCallback onTap;
-  const _IconCircle({required this.icon, required this.onTap});
+  final Color? color;
+  const _IconCircle({required this.icon, required this.onTap, this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -276,7 +339,7 @@ class _IconCircle extends StatelessWidget {
           color: AfColors.surfaceBase,
           shape: BoxShape.circle,
         ),
-        child: Icon(icon, size: 22, color: AfColors.textPrimary),
+        child: Icon(icon, size: 22, color: color ?? AfColors.textPrimary),
       ),
     );
   }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -78,7 +78,7 @@ class HomeScreen extends ConsumerWidget {
               child: SectionHeader(
                 title: 'Recently played',
                 actionLabel: 'See more',
-                onActionTap: () {},
+                onActionTap: () => context.go('/library'),
               ),
             ),
           ),

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -38,7 +38,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 const Spacer(),
                 IconButton(
                   icon: const Icon(Icons.sort_rounded),
-                  onPressed: () {},
+                  onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Sort coming soon'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  ),
                   tooltip: 'Sort',
                 ),
               ],

--- a/lib/features/now_playing/now_playing_screen.dart
+++ b/lib/features/now_playing/now_playing_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:just_audio/just_audio.dart' show LoopMode;
 
 import '../../core/demo/demo_library.dart';
 import '../../core/jellyfin/models/items.dart';
@@ -123,7 +124,11 @@ class NowPlayingScreen extends ConsumerWidget {
                                     ? AfColors.semanticError
                                     : AfColors.textPrimary,
                               ),
-                              onPressed: () {},
+                              tooltip: track.isFavorite
+                                  ? 'Remove from favorites'
+                                  : 'Add to favorites',
+                              onPressed: () =>
+                                  ref.read(favoriteToggleProvider)(track),
                             ),
                             if (track.quality != null)
                               QualityChip(quality: track.quality!),
@@ -167,6 +172,32 @@ class NowPlayingScreen extends ConsumerWidget {
                         _TransportRow(
                           isPlaying: isPlaying,
                           spectral: spectral,
+                          shuffleOn: ref
+                              .watch(shuffleModeProvider)
+                              .maybeWhen(
+                                data: (v) => v,
+                                orElse: () => false,
+                              ),
+                          loopMode: ref
+                              .watch(loopModeProvider)
+                              .maybeWhen(
+                                data: (v) => v,
+                                orElse: () => LoopMode.off,
+                              ),
+                          accent: spectral.energy,
+                          onShuffle: () {
+                            final svc = ref.read(playerServiceProvider);
+                            svc.setAfShuffleMode(!svc.isShuffleEnabled);
+                          },
+                          onRepeat: () {
+                            final svc = ref.read(playerServiceProvider);
+                            final next = switch (svc.loopMode) {
+                              LoopMode.off => LoopMode.all,
+                              LoopMode.all => LoopMode.one,
+                              LoopMode.one => LoopMode.off,
+                            };
+                            svc.setAfLoopMode(next);
+                          },
                           onPlayPause: () {
                             final svc =
                                 ref.read(playerServiceProvider);
@@ -178,7 +209,7 @@ class NowPlayingScreen extends ConsumerWidget {
                               ref.read(playerServiceProvider).skipToNext(),
                         ),
                         const SizedBox(height: AfSpacing.s32),
-                        _UtilityRow(),
+                        const _UtilityRow(),
                         const SizedBox(height: AfSpacing.s24),
                       ],
                     ),
@@ -231,7 +262,12 @@ class _TopBar extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.more_horiz_rounded),
-            onPressed: () {},
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('More options coming soon'),
+                duration: Duration(seconds: 2),
+              ),
+            ),
           ),
         ],
       ),
@@ -242,16 +278,26 @@ class _TopBar extends StatelessWidget {
 class _TransportRow extends StatelessWidget {
   final bool isPlaying;
   final Spectral spectral;
+  final bool shuffleOn;
+  final LoopMode loopMode;
+  final Color accent;
   final VoidCallback onPlayPause;
   final VoidCallback onPrev;
   final VoidCallback onNext;
+  final VoidCallback onShuffle;
+  final VoidCallback onRepeat;
 
   const _TransportRow({
     required this.isPlaying,
     required this.spectral,
+    required this.shuffleOn,
+    required this.loopMode,
+    required this.accent,
     required this.onPlayPause,
     required this.onPrev,
     required this.onNext,
+    required this.onShuffle,
+    required this.onRepeat,
   });
 
   @override
@@ -262,7 +308,8 @@ class _TransportRow extends StatelessWidget {
         _TransportButton(
           icon: Icons.shuffle_rounded,
           size: 28,
-          onTap: () {},
+          color: shuffleOn ? accent : AfColors.textPrimary,
+          onTap: onShuffle,
         ),
         _TransportButton(
           icon: Icons.skip_previous_rounded,
@@ -280,9 +327,14 @@ class _TransportRow extends StatelessWidget {
           onTap: onNext,
         ),
         _TransportButton(
-          icon: Icons.repeat_rounded,
+          icon: loopMode == LoopMode.one
+              ? Icons.repeat_one_rounded
+              : Icons.repeat_rounded,
           size: 28,
-          onTap: () {},
+          color: loopMode == LoopMode.off
+              ? AfColors.textPrimary
+              : accent,
+          onTap: onRepeat,
         ),
       ],
     );
@@ -293,10 +345,12 @@ class _TransportButton extends StatelessWidget {
   final IconData icon;
   final double size;
   final VoidCallback onTap;
+  final Color? color;
   const _TransportButton({
     required this.icon,
     required this.size,
     required this.onTap,
+    this.color,
   });
 
   @override
@@ -306,7 +360,7 @@ class _TransportButton extends StatelessWidget {
       child: SizedBox(
         width: AfSpacing.minHitTarget,
         height: AfSpacing.minHitTarget,
-        child: Icon(icon, size: size, color: AfColors.textPrimary),
+        child: Icon(icon, size: size, color: color ?? AfColors.textPrimary),
       ),
     );
   }
@@ -353,23 +407,109 @@ class _PlayButton extends StatelessWidget {
   }
 }
 
-class _UtilityRow extends StatelessWidget {
+class _UtilityRow extends ConsumerWidget {
+  const _UtilityRow();
+
   @override
-  Widget build(BuildContext context) {
-    final items = const [
-      (Icons.bedtime_outlined, 'Sleep', '/sleep'),
-      (Icons.lyrics_outlined, 'Lyrics', '/lyrics'),
-      (Icons.speed_rounded, 'Speed', null),
-      (Icons.cast_outlined, 'Output', '/cast'),
-      (Icons.playlist_add_rounded, 'Save', null),
-      (Icons.queue_music_rounded, 'Queue', '/queue'),
-    ];
+  Widget build(BuildContext context, WidgetRef ref) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        for (final (icon, label, route) in items)
-          _UtilityIcon(icon: icon, label: label, route: route),
+        _UtilityIcon(
+          icon: Icons.bedtime_outlined,
+          label: 'Sleep',
+          onTap: () => context.push('/sleep'),
+        ),
+        _UtilityIcon(
+          icon: Icons.lyrics_outlined,
+          label: 'Lyrics',
+          onTap: () => context.push('/lyrics'),
+        ),
+        _UtilityIcon(
+          icon: Icons.speed_rounded,
+          label: 'Speed',
+          onTap: () => _showSpeedSheet(context, ref),
+        ),
+        _UtilityIcon(
+          icon: Icons.cast_outlined,
+          label: 'Output',
+          onTap: () => context.push('/cast'),
+        ),
+        _UtilityIcon(
+          icon: Icons.playlist_add_rounded,
+          label: 'Save',
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Playlists coming soon'),
+                duration: Duration(seconds: 2),
+              ),
+            );
+          },
+        ),
+        _UtilityIcon(
+          icon: Icons.queue_music_rounded,
+          label: 'Queue',
+          onTap: () => context.push('/queue'),
+        ),
       ],
+    );
+  }
+
+  void _showSpeedSheet(BuildContext context, WidgetRef ref) {
+    const speeds = <double>[0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+    final current = ref.read(playerServiceProvider).speed;
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AfColors.surfaceBase,
+      shape: const RoundedRectangleBorder(
+        borderRadius:
+            BorderRadius.vertical(top: Radius.circular(AfRadii.lg)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: AfSpacing.s12),
+            Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AfColors.textTertiary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: AfSpacing.s12),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AfSpacing.gutterGenerous,
+              ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Playback speed',
+                  style: AfTypography.titleSmall,
+                ),
+              ),
+            ),
+            for (final s in speeds)
+              ListTile(
+                title: Text(
+                  '${s.toStringAsFixed(s == s.roundToDouble() ? 1 : 2)}×',
+                  style: AfTypography.bodyMedium,
+                ),
+                trailing: (s - current).abs() < 0.001
+                    ? const Icon(Icons.check_rounded, size: 20)
+                    : null,
+                onTap: () {
+                  ref.read(playerServiceProvider).setAfSpeed(s);
+                  Navigator.of(sheetCtx).pop();
+                },
+              ),
+            const SizedBox(height: AfSpacing.s12),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -377,18 +517,18 @@ class _UtilityRow extends StatelessWidget {
 class _UtilityIcon extends StatelessWidget {
   final IconData icon;
   final String label;
-  final String? route;
+  final VoidCallback onTap;
   const _UtilityIcon({
     required this.icon,
     required this.label,
-    required this.route,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     return PressScale(
       ensureHitTarget: false,
-      onTap: route == null ? null : () => context.push(route!),
+      onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: AfSpacing.s8),
         child: Column(

--- a/lib/features/queue/queue_screen.dart
+++ b/lib/features/queue/queue_screen.dart
@@ -54,11 +54,25 @@ class _QueueScreenState extends ConsumerState<QueueScreen> {
         ),
         title: Text('Queue', style: AfTypography.titleSmall),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.shuffle_rounded),
-            onPressed: () {},
-            tooltip: 'Shuffle',
-          ),
+          Consumer(builder: (context, ref, _) {
+            final shuffleOn = ref.watch(shuffleModeProvider).maybeWhen(
+                  data: (v) => v,
+                  orElse: () => false,
+                );
+            return IconButton(
+              icon: Icon(
+                Icons.shuffle_rounded,
+                color: shuffleOn
+                    ? AfColors.indigo300
+                    : AfColors.textPrimary,
+              ),
+              tooltip: shuffleOn ? 'Shuffle on' : 'Shuffle',
+              onPressed: () {
+                final svc = ref.read(playerServiceProvider);
+                svc.setAfShuffleMode(!svc.isShuffleEnabled);
+              },
+            );
+          }),
           IconButton(
             icon: const Icon(Icons.lyrics_outlined),
             onPressed: () => context.go('/lyrics'),

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart' show LoopMode;
 
 import '../core/audio/jellyfin_playback_reporter.dart';
 import '../core/audio/player_service.dart';
@@ -166,9 +167,86 @@ final playingStreamProvider = StreamProvider.autoDispose<bool>((ref) {
   return svc.playingStream;
 });
 
+/// Live shuffle flag — drives the shuffle icon's active tint in
+/// Now Playing / Queue. Seeded with the player's current value so the
+/// first frame matches reality without waiting for the next emit.
+final shuffleModeProvider = StreamProvider.autoDispose<bool>((ref) {
+  final svc = ref.watch(playerServiceProvider);
+  return Stream<bool>.multi((controller) {
+    controller.add(svc.isShuffleEnabled);
+    final sub = svc.shuffleModeStream.listen(controller.add);
+    controller.onCancel = sub.cancel;
+  });
+});
+
+/// Live loop mode — drives the repeat icon (off / all / one) in
+/// Now Playing.
+final loopModeProvider = StreamProvider.autoDispose<LoopMode>((ref) {
+  final svc = ref.watch(playerServiceProvider);
+  return Stream<LoopMode>.multi((controller) {
+    controller.add(svc.loopMode);
+    final sub = svc.loopModeStream.listen(controller.add);
+    controller.onCancel = sub.cancel;
+  });
+});
+
+/// Live playback speed multiplier — drives the Speed sheet's checkmark.
+final playbackSpeedProvider = StreamProvider.autoDispose<double>((ref) {
+  final svc = ref.watch(playerServiceProvider);
+  return Stream<double>.multi((controller) {
+    controller.add(svc.speed);
+    final sub = svc.speedStream.listen(controller.add);
+    controller.onCancel = sub.cancel;
+  });
+});
+
 /// Currently-playing track (changes when the player advances within
 /// the queue). Null when no playback has been started this session.
 final currentTrackProvider = StateProvider<AfTrack?>((ref) => null);
+
+/// Imperative helper to toggle a track's favorite state.
+///
+/// Optimistically flips the in-memory `currentTrackProvider.isFavorite`
+/// so the heart fills/empties on the next frame, then POSTs/DELETEs
+/// `/Users/{id}/FavoriteItems/{trackId}`. On HTTP failure we revert.
+///
+/// Signed-out (no client) → updates the local state only; the next sign-in
+/// will resync against the server's user-data on the next track fetch.
+final favoriteToggleProvider = Provider<Future<void> Function(AfTrack)>((ref) {
+  return (AfTrack track) async {
+    final client = ref.read(jellyfinClientProvider);
+    final next = !track.isFavorite;
+    final updated = track.copyWith(isFavorite: next);
+    // Optimistic UI: update currentTrackProvider if this is the playing
+    // track. (Album / Track tiles read isFavorite from their own
+    // FutureProvider snapshots which will refresh next time their
+    // provider re-runs.)
+    final current = ref.read(currentTrackProvider);
+    if (current?.id == track.id) {
+      ref.read(currentTrackProvider.notifier).state = updated;
+    }
+    if (client == null) {
+      _logData('favoriteToggle',
+          source: 'demo',
+          extra: '(signed out) id=${track.id} isFavorite=$next');
+      return;
+    }
+    try {
+      await client.setFavorite(track.id, next);
+      _logData('favoriteToggle',
+          source: 'live',
+          extra: 'id=${track.id} isFavorite=$next');
+    } catch (e) {
+      // ignore: avoid_print
+      print('aetherfin:error favoriteToggle failed: $e');
+      // Revert optimistic flip on server error.
+      if (current?.id == track.id) {
+        ref.read(currentTrackProvider.notifier).state = track;
+      }
+      rethrow;
+    }
+  };
+});
 
 /// True the moment any playback has been started this session — drives
 /// whether the floating mini-player is rendered.


### PR DESCRIPTION
## Summary

After PR #4 fixed the actual audio decoding, the user reported "all buttons do nothing except play/pause" on Now Playing. They were right — most of the auxiliary buttons were `onPressed: () {}` / `onTap: () {}` stubs. This PR wires them all to real player + Jellyfin actions.

### Now wired

| Button | Was | Now |
|---|---|---|
| **Shuffle** (Now Playing transport) | `() {}` | Toggles `just_audio` shuffle mode (`_player.shuffle()` then `setShuffleModeEnabled`). Icon tints accent when on. |
| **Repeat** (Now Playing transport) | `() {}` | Cycles `off → all → one`. Icon swaps to `repeat_one_rounded` for `one` and tints accent for non-off. |
| **Heart** (Now Playing title row) | `() {}` | `POST /Users/{id}/FavoriteItems/{trackId}` (`DELETE` on un-favorite). Optimistically updates `currentTrackProvider.isFavorite`, reverts on HTTP error. |
| **Speed** (Now Playing utility row) | `route: null` | Bottom sheet with 0.5 → 2.0 multipliers, checkmark on the active one. Calls `_player.setSpeed()`. |
| **Shuffle** (Queue app bar) | `() {}` | Same `setAfShuffleMode` toggle as Now Playing; tints `indigo300` when active. |
| **Favorite circle** (Album detail) | `() {}` | `POST /Users/{id}/FavoriteItems/{albumId}`. Optimistic UI with busy lockout. |
| **“See more”** (Home Recently played) | `() {}` | Navigates to `/library`. |

### Acknowledged-but-deferred (snackbar stubs)

These show a `Coming soon` snackbar so the user sees the tap was registered:

- Now Playing "Save" (Save to playlist) — needs playlist-pick UI.
- Now Playing top-bar "⋯" (more options) — needs context menu sheet.
- Album "Download" (offline cache) — separate offline-storage workstream.
- Album "More options" (⋯ twice in `_ActionRow` + app bar).
- Library "Sort" — needs sort UI + provider param wiring.

### New plumbing

- `JellyfinClient.setFavorite(itemId, isFavorite)` wraps both POST and DELETE on `/Users/{userId}/FavoriteItems/{itemId}`.
- `AfPlayerService.setAfShuffleMode / setAfLoopMode / setAfSpeed` + matching streams + cached getters. The `af` prefix avoids colliding with `BaseAudioHandler.setShuffleMode(AudioServiceShuffleMode)` / `setRepeatMode(AudioServiceRepeatMode)` which the OS lock screen calls with different enum types.
- `shuffleModeProvider` / `loopModeProvider` / `playbackSpeedProvider` stream the player's current state, seeded with an immediate first emit so toggles light up on the first frame instead of waiting for the next user-driven event.
- `favoriteToggleProvider` centralises optimistic update + revert-on-error so any list/tile can reuse it later.

### Review & Testing Checklist for Human

- [ ] **Shuffle** — tap on Now Playing, icon tints. Skip tracks; new order is randomised. Tap again, icon de-tints, order returns to album order on next track.
- [ ] **Repeat** — tap, icon tints (loop-all). Tap again, icon switches to `repeat_one_rounded` (loop-one). Tap third time, icon goes back to neutral.
- [ ] **Heart** — tap, heart fills red. Reload track from server (or check Jellyfin Dashboard → user → favorites) and confirm it persisted. Tap again, heart empties + server entry removed.
- [ ] **Speed** — tap "Speed" in utility row; bottom sheet appears. Pick 1.5×. Audio speeds up; checkmark on 1.5× sheet item; current sheet entry persists if reopened.
- [ ] **Queue shuffle** — same as Now Playing shuffle; icon turns indigo when on.
- [ ] **Album favorite** — open an album, tap the heart circle; heart fills. Check Jellyfin Dashboard. Tap again to remove.
- [ ] **No regressions** — play/pause, prev/next, seek (waveform scrub), and lock-screen controls still behave as before.

### Test plan

1. `flutter analyze --no-fatal-infos` → 0 errors / 0 warnings (verified locally, 49 info-only items, all preexisting).
2. `flutter test` → 6/6 pass.
3. APK build dispatched after merge so it can be smoke-tested on device.

### Notes

- Heart on album uses local `_isFavorite` because `AfAlbum` doesn't yet carry `isFavorite` from `/Users/{id}/Items` — first tap always optimistically goes to "true". A follow-up should plumb `UserData.IsFavorite` through `AfAlbum` so the initial state matches the server.
- No `json_serializable` added.
- `CLAUDE.md` is unchanged — no new patterns to document, just additional methods on existing classes.