### PR TITLE
Add LICENSE, TERMS, PRIVACY and rewrite README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Azrim <mirzaspc@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,154 @@
+# Privacy Policy
+
+**Effective date:** May 11, 2026
+**Author / maintainer:** Azrim &lt;mirzaspc@gmail.com&gt;
+**Software:** Aetherfin — an open-source Android music player
+**Repository:** <https://github.com/Aetherfin/mobile-app>
+
+Short version: **Aetherfin does not collect, transmit, or sell any
+personal data.** It is a client that talks only to the Jellyfin server
+you configure. Everything else stays on your phone.
+
+The rest of this document explains what data the App handles, where it
+lives, and what we (the maintainer) do and do not see.
+
+---
+
+## 1. Who runs Aetherfin
+
+Aetherfin is open-source software maintained by Azrim
+(&lt;mirzaspc@gmail.com&gt;). **There is no Aetherfin-operated server, no
+account system, and no telemetry pipeline.** The maintainer does not
+host, receive, store, or analyze any of your activity.
+
+If you obtain a build of Aetherfin from a source other than the
+[official repository](https://github.com/Aetherfin/mobile-app), this
+policy describes only the behavior of unmodified upstream builds. Forks
+or third-party redistributions may add their own data collection and
+are out of scope of this policy.
+
+## 2. What data the App handles
+
+| Data | Where it lives | Who sees it |
+|---|---|---|
+| Jellyfin **server URL** (e.g. `http://omahsangar.local:8097`) | `flutter_secure_storage` on your device | You + your Jellyfin server |
+| Jellyfin **username** | `flutter_secure_storage` on your device | You + your Jellyfin server |
+| Jellyfin **access token** (issued by your server on sign-in) | `flutter_secure_storage` on your device | You + your Jellyfin server |
+| Jellyfin **user ID** | `flutter_secure_storage` on your device | You + your Jellyfin server |
+| **Device ID** — random 16-byte value generated on first launch and used as Jellyfin's `DeviceId` for session bookkeeping | `flutter_secure_storage` on your device | Your Jellyfin server |
+| **Settings** (audio-quality preference, crossfade, sleep-timer state, sort order, theme overrides) | `shared_preferences` on your device | Only you |
+| **Cover-art image cache** | `cached_network_image` files in the App's private cache directory | Only you |
+| **HTTP cache** of catalog requests | Dio cache files in the App's private cache directory | Only you |
+| **Lyrics (LRC files)** fetched from your Jellyfin server | In-memory only — not persisted | Only you, while playing |
+| **Playback state** (current track, position, queue) | In-memory + lock-screen `MediaSession` | Only you |
+| **Diagnostic logs** (`aetherfin:boot`, `aetherfin:http`, `aetherfin:data`, `aetherfin:audio`, `aetherfin:error`) | Standard Android logcat buffer (volatile, capped by the OS) | Only you, when you run `adb logcat` |
+
+**Aetherfin does not send any of the above to the maintainer or any
+third party.** The only network destination Aetherfin contacts is the
+Jellyfin server URL you provide.
+
+## 3. What Aetherfin sends to your Jellyfin server
+
+The App is a client for the Jellyfin HTTP API. When you sign in and use
+the App it sends the same requests any Jellyfin client (Finamp, the
+official web client, etc.) would send, including:
+
+- **Authentication:** `POST /Users/AuthenticateByName` (your username
+  and password) — sent only once per sign-in to obtain an access token.
+- **Catalog reads:** `GET /Users/{id}/Items`, `/Users/{id}/Items/Latest`,
+  `/Users/{id}/Items/Resume`, `/Items/{id}/Images/Primary`, etc. —
+  necessary to render the library, album, artist, and queue screens.
+- **Audio streaming:** `GET /Audio/{id}/stream?Static=true` — direct
+  byte-for-byte download of the audio file you chose to play.
+- **Library state writes:**
+  - `POST` / `DELETE /Users/{id}/FavoriteItems/{id}` when you tap the
+    heart icon (favorite / un-favorite).
+  - `POST /Sessions/Playing`, `POST /Sessions/Playing/Progress`, and
+    `POST /Sessions/Playing/Stopped` so your Jellyfin dashboard shows
+    what you're currently playing, and so play counts and
+    last-played-at timestamps are updated. These can be disabled by
+    your Jellyfin server administrator if desired.
+
+Your Jellyfin server logs and stores this data according to its own
+configuration, which is **outside the control of the App and its
+maintainer**. Refer to your Jellyfin server administrator for its
+retention and access policy.
+
+## 4. What Aetherfin does NOT do
+
+- No analytics SDK is integrated (no Firebase Analytics, Mixpanel,
+  Amplitude, Sentry, Crashlytics, etc.).
+- No advertising SDK is integrated. No ads are served.
+- No telemetry, "anonymous usage statistics", "diagnostic data", or
+  "improvement program" payloads are sent to the maintainer or any
+  third party.
+- No background location, contacts, calendar, SMS, or call-log access
+  is requested or used.
+- The App does not phone home on launch. The only initial network call
+  is to the Jellyfin server URL you typed during onboarding.
+
+You can verify this by reading the source code at
+<https://github.com/Aetherfin/mobile-app>. The full list of network
+endpoints the App touches is enumerated in `lib/core/jellyfin/client.dart`.
+
+## 5. Android permissions Aetherfin requests
+
+| Permission | Why |
+|---|---|
+| `INTERNET` | To talk to your Jellyfin server. |
+| `ACCESS_NETWORK_STATE` | So the App can react to your phone being offline. |
+| `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` (Android 14+) | So music keeps playing when the App is backgrounded, via Android's standard media session. |
+| `WAKE_LOCK` | So the CPU stays awake long enough to decode the next chunk of audio when the screen is off. |
+
+The App does **not** request location, microphone, camera, contacts, or
+storage permissions.
+
+## 6. Children's privacy
+
+Aetherfin is not directed to children under 13. The App itself collects
+no information from anyone — children or otherwise — and transmits none
+to the maintainer. Whether the content on your Jellyfin server is
+appropriate for children is a matter for the server's owner.
+
+## 7. Security
+
+Credentials and access tokens are stored using Android's
+[`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage),
+which on modern Android uses the Android Keystore. Encrypted-at-rest
+where the OS provides it.
+
+That said, **rooted devices, malware, and physical access by a third
+party can defeat any on-device storage**. If you believe your device
+has been compromised, sign out from Settings → Profile → Sign out
+(which deletes the stored token from secure storage) and revoke the
+token in your Jellyfin server's "Devices" dashboard.
+
+## 8. Open-source verifiability
+
+Aetherfin is **open-source under the MIT License**. The entire client
+behavior — every HTTP call, every storage write — is visible at:
+
+> <https://github.com/Aetherfin/mobile-app>
+
+If you want to verify the claims in this policy, the relevant files are:
+
+- `lib/core/jellyfin/client.dart` — the only file that issues HTTP
+  requests.
+- `lib/core/jellyfin/auth_storage.dart` — the secure-storage adapter.
+- `lib/state/providers.dart` — every data fetch the UI watches.
+- `lib/main.dart` — bootstrap and initialization.
+
+## 9. Changes to this policy
+
+The maintainer may update this policy from time to time. The current
+version is always the file `PRIVACY.md` at the root of the
+[Aetherfin repository](https://github.com/Aetherfin/mobile-app). Material
+changes — for example, if the App ever started collecting data — will
+be called out in the commit message and the release notes for the
+build that introduces them.
+
+## 10. Contact
+
+Privacy questions or requests can be sent to **mirzaspc@gmail.com** or
+filed as a GitHub Issue on the
+[Aetherfin repository](https://github.com/Aetherfin/mobile-app/issues).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,165 @@
-# aetherfin
+# Aetherfin
 
-Aetherfin — a Jellyfin-backed music player for Android
+A native-feeling Android music player backed by your self-hosted
+[Jellyfin](https://jellyfin.org) server. Aetherfin is the player —
+Jellyfin is the file source.
 
-## Getting Started
+> Spotify's polish. Apple Music's typography. Soulseek's respect for the
+> listener.
 
-This project is a starting point for a Flutter application.
+[![Flutter](https://img.shields.io/badge/Flutter-3.41.9-02569B?logo=flutter)](https://flutter.dev)
+[![Dart](https://img.shields.io/badge/Dart-3.11.5-0175C2?logo=dart)](https://dart.dev)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Android](https://img.shields.io/badge/Android-5.0%2B-3DDC84?logo=android)](https://developer.android.com)
 
-A few resources to get you started if this is your first Flutter project:
+---
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+## What it is
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Aetherfin streams music from a Jellyfin server you own and decodes it
+fully on-device. No Aetherfin-operated servers exist. No telemetry.
+Jellyfin is treated as a passive file source plus per-user state store
+(favorites, play counts, playlists). Everything else — buffering,
+decoding, queue management, lyrics, lock-screen controls, sleep timer,
+spectral color extraction — runs on your phone.
+
+**Why this matters**
+
+- The Jellyfin server's CPU stays cool. Tracks are served as raw bytes
+  via `/Audio/{id}/stream?Static=true`. No HLS transcoding round-trip.
+- You can play lossless FLAC / ALAC / OPUS files without quality loss.
+- Aetherfin keeps working as long as your Jellyfin server is reachable
+  on the network. There is no "Aetherfin cloud" to depend on.
+
+## Features
+
+- **Library, Albums, Artists, Genres, Playlists** browsing
+- **Search** (`/Users/{id}/Items?searchTerm=…`)
+- **Queue** with drag-to-reorder
+- **Now Playing** with waveform scrubbing, shuffle, loop (off / all / one),
+  playback speed (0.5×–2.0×), favorite toggle
+- **Synced lyrics** (LRC parsed on-device)
+- **Lock-screen / notification** media controls via
+  [`audio_service`](https://pub.dev/packages/audio_service)
+- **Sleep timer**, **cast picker** (output routing)
+- **mDNS discovery** of Jellyfin servers on the local network
+- **Spectral-derived UI accents** — palette is sampled from the current
+  cover art
+- **Offline-friendly metadata cache** (cover art via
+  [`cached_network_image`](https://pub.dev/packages/cached_network_image),
+  Dio HTTP cache for catalog requests)
+
+## Screenshots
+
+> Coming soon. In the meantime, see the
+> [APK builds](https://github.com/Aetherfin/mobile-app/actions/workflows/build-apk.yml)
+> — install the latest one and try it against your own server.
+
+## Requirements
+
+- **Android 5.0 (API 21)** or newer.
+- A reachable [**Jellyfin 10.8+**](https://jellyfin.org/downloads/server)
+  server with at least one music library.
+- Network reachability between phone and server (LAN, VPN, or
+  publicly-exposed HTTPS — all work).
+
+## Quick start
+
+### Install the APK
+
+1. Download the most recent `app-release.apk` (or per-ABI variant) from
+   [Releases](https://github.com/Aetherfin/mobile-app/releases) or the
+   [latest CI build](https://github.com/Aetherfin/mobile-app/actions/workflows/build-apk.yml).
+2. Enable "Install from unknown sources" for your file manager / browser.
+3. Open the APK, install, launch.
+
+### First-run onboarding
+
+1. **Discover or enter your server URL** (e.g. `http://omahsangar.local:8097`
+   or `https://music.example.com`). mDNS will list nearby Jellyfin
+   instances; otherwise type the URL manually.
+2. **Sign in** with your Jellyfin username and password. Aetherfin uses
+   the standard Jellyfin auth flow (`POST /Users/AuthenticateByName`).
+3. **You're in.** Pick a track. It plays.
+
+## Building from source
+
+```bash
+# Prereqs: Flutter 3.41.9 stable, Dart 3.11.5, Java 17, Android SDK
+flutter --version    # must say 3.41.9
+flutter pub get
+
+# Run on a connected device / emulator
+flutter run --debug
+
+# Release APK
+flutter build apk --release
+# → build/app/outputs/flutter-apk/app-release.apk
+
+# Per-ABI APKs (smaller download per device)
+flutter build apk --release --split-per-abi
+```
+
+### Pre-push checklist
+
+```bash
+flutter analyze --no-fatal-infos   # 0 errors, 0 warnings
+flutter test                       # 6/6 pass
+```
+
+CI runs both on every PR. See
+[`.github/workflows/build-apk.yml`](.github/workflows/build-apk.yml).
+
+## Architecture (the 30-second version)
+
+```
+   ┌────────────────────────────┐         ┌──────────────────────────────┐
+   │   Aetherfin (Android)      │         │   Your Jellyfin server       │
+   │                            │         │                              │
+   │  ExoPlayer (just_audio) ◄──┼─bytes───┤  /Audio/{id}/stream          │
+   │  Queue / shuffle / loop    │         │   ?Static=true               │
+   │  Lyrics parse + sync       │◄─meta───┤  /Users/{id}/Items …         │
+   │  Lock-screen controls      │         │  /Users/{id}/FavoriteItems   │
+   │  Cover-art file cache      │◄─image──┤  /Items/{id}/Images/Primary  │
+   │                            │         │                              │
+   │  Optimistic favorite UI ───┼─POST────┤  (server is source of truth) │
+   │  Telemetry (display only) ─┼─POST────┤  /Sessions/Playing[/Progress]│
+   └────────────────────────────┘         └──────────────────────────────┘
+```
+
+Full architectural rules live in [`CLAUDE.md`](./CLAUDE.md), the
+guide for any agent or human contributor.
+
+## Privacy
+
+Aetherfin does not operate any servers. The app talks only to the
+Jellyfin server you configure. Credentials live in Android's secure
+storage on the device. No analytics, no crash-reporting SDK, no ads,
+no third-party trackers. Full statement in [PRIVACY.md](./PRIVACY.md).
+
+## License
+
+Aetherfin is open-source under the **MIT License**. See
+[LICENSE](./LICENSE) for the full text.
+
+Copyright © 2025 Azrim &lt;mirzaspc@gmail.com&gt;.
+
+Jellyfin is © its respective authors and is licensed separately. This
+project is not affiliated with the Jellyfin project.
+
+## Contributing
+
+PRs welcome. Read [CLAUDE.md](./CLAUDE.md) first — it covers the auth
+header format, the data-source split, the design tokens, and the
+non-negotiable rules. Branches are named `devin/<timestamp>-<slug>` for
+agent-authored work; humans can use any naming they like.
+
+## Acknowledgements
+
+- [Jellyfin](https://jellyfin.org) — the free software media system this
+  app is built around.
+- [Finamp](https://github.com/jmshrv/finamp) — the prior-art Jellyfin
+  music client whose auth-header format we follow.
+- [just_audio](https://pub.dev/packages/just_audio) and
+  [audio_service](https://pub.dev/packages/audio_service) — the audio
+  + lock-screen plumbing.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,157 @@
+# Terms of Service
+
+**Effective date:** May 11, 2026
+**Author / maintainer:** Azrim &lt;mirzaspc@gmail.com&gt;
+**Software:** Aetherfin — an open-source Android music player
+**Repository:** <https://github.com/Aetherfin/mobile-app>
+
+These Terms of Service ("Terms") govern your use of the Aetherfin
+application ("Aetherfin", "the App"). By installing, launching, or using
+Aetherfin you agree to these Terms. If you do not agree, do not install
+or use the App.
+
+Aetherfin is open-source software licensed under the MIT License — see
+[LICENSE](./LICENSE) for the controlling legal terms. These Terms are
+supplementary to the LICENSE and do not override it.
+
+---
+
+## 1. What Aetherfin is, and what it isn't
+
+Aetherfin is a **client** application that connects to a
+[Jellyfin](https://jellyfin.org) media server **that you operate or
+otherwise have authorization to access**. The App streams audio from
+that server and renders the catalog locally on your Android device.
+
+Aetherfin does **not**:
+
+- Operate any servers of its own. There is no "Aetherfin cloud".
+- Host, distribute, or supply any music, video, image, or text content.
+- Provide an account system. Your identity is your Jellyfin account on
+  your Jellyfin server.
+- Sell, license, or sublicense any media content.
+
+All media content you access through Aetherfin is supplied by, and
+remains the responsibility of, the Jellyfin server you connect to.
+
+## 2. You are responsible for what you do with the App
+
+You are solely responsible for:
+
+- **Owning or having the legal right** to access the media stored on the
+  Jellyfin server you connect to.
+- **Complying with the laws** of your jurisdiction with respect to
+  storing, streaming, and listening to that media.
+- **The configuration, operation, security, and lawful use of any
+  Jellyfin server** you connect to. The maintainer of Aetherfin has no
+  visibility into, and no control over, your server.
+- **Your network connection**, including any data charges your mobile
+  carrier may impose for streaming.
+
+If you do not have the legal right to access a particular library or
+file on a Jellyfin server, do not access it through Aetherfin.
+
+## 3. Acceptable use
+
+You agree not to use Aetherfin to:
+
+- Access any Jellyfin server without the owner's permission.
+- Circumvent technical or legal access controls on media content.
+- Distribute, retransmit, or publicly perform media content beyond what
+  the content's license permits.
+- Reverse-engineer, repackage, or redistribute the App in a way that
+  removes the MIT License notice, copyright attribution, or these Terms.
+- Interfere with, disrupt, or attempt to gain unauthorized access to any
+  Jellyfin server or its underlying infrastructure.
+
+## 4. Open-source license & modifications
+
+The App's source code is licensed under the **MIT License**. You may
+copy, modify, distribute, and create derivative works in accordance with
+that license. If you redistribute a modified build, you must:
+
+- Retain the original copyright notice and the MIT License text
+  (`LICENSE`).
+- Clearly identify your build as a modified version (e.g. a different
+  Application ID, app name, or version string), so end-users understand
+  they are not using an upstream Aetherfin build.
+
+The maintainer of upstream Aetherfin is not responsible for the
+behavior, security, or content of forks or third-party builds.
+
+## 5. No warranty
+
+Aetherfin is provided **"AS IS", without warranty of any kind**,
+express or implied, including but not limited to the warranties of
+merchantability, fitness for a particular purpose, and non-infringement.
+The maintainer makes no guarantee that:
+
+- The App will be available, error-free, or compatible with every
+  Jellyfin server version, plugin, or Android device.
+- Audio playback, lyrics sync, offline cache, or any other feature will
+  behave correctly in every environment.
+- Server-side actions taken by Aetherfin (e.g. updating a track's
+  favorite state, reporting playback sessions) will always succeed.
+
+You install and run Aetherfin at your own risk.
+
+## 6. Limitation of liability
+
+To the maximum extent permitted by applicable law, in no event shall the
+maintainer or contributors be liable for any indirect, incidental,
+special, consequential, or punitive damages, or any loss of profits,
+data, use, goodwill, or other intangible losses, arising out of or in
+connection with your use of, or inability to use, the App — even if
+advised of the possibility of such damages.
+
+If applicable law does not allow the exclusion of certain warranties or
+the limitation of liability for incidental or consequential damages,
+some of the above limitations may not apply to you. In such cases the
+maintainer's liability shall be limited to the greatest extent permitted
+by law.
+
+## 7. Third-party components
+
+Aetherfin uses third-party open-source libraries (Flutter, just_audio,
+audio_service, dio, flutter_riverpod, cached_network_image,
+flutter_secure_storage, palette_generator, etc.) and connects to
+Jellyfin servers operated by their respective owners. These components
+are licensed separately and are not maintained by the Aetherfin author.
+
+## 8. No content rights granted
+
+Nothing in these Terms transfers to you any right, title, or interest in
+the music, artwork, lyrics, metadata, or other media you access through
+the App. All such rights remain with the content owners.
+
+## 9. Changes to these Terms
+
+The maintainer may update these Terms from time to time. The current
+version is always the file `TERMS.md` at the root of the
+[Aetherfin repository](https://github.com/Aetherfin/mobile-app). Your
+continued use of the App after an update means you accept the updated
+Terms.
+
+## 10. Termination
+
+You may stop using Aetherfin at any time by signing out and uninstalling
+the App. The maintainer may discontinue the project, change its scope,
+or stop publishing builds at any time without notice — consistent with
+the MIT License.
+
+Sections 5 (No warranty), 6 (Limitation of liability), and 8 (No content
+rights granted) survive termination.
+
+## 11. Governing law
+
+These Terms are governed by the laws of the jurisdiction in which the
+maintainer ordinarily resides, except as otherwise required by
+mandatory consumer-protection law applicable to you. Any dispute that
+cannot be resolved informally shall be brought in the courts having
+jurisdiction over that location.
+
+## 12. Contact
+
+Issues, questions, or notices regarding these Terms can be filed via
+GitHub Issues on the [Aetherfin repository](https://github.com/Aetherfin/mobile-app/issues)
+or by emailing the maintainer at **mirzaspc@gmail.com**.


### PR DESCRIPTION
## Summary

Project documentation upgrade. Four files:

- **`README.md`** — rewritten from scratch. The repo shipped with the default `flutter create` template, which made the project look like a tutorial scaffold. The new README has a project-specific intro, feature list (matches what's wired in the current build incl. shuffle / loop / speed / favorites / lyrics / sleep / cast), build instructions for the per-ABI split APK, and an ASCII architecture diagram lifted from CLAUDE.md §1.1.

- **`LICENSE`** — standard MIT, `Copyright (c) 2025 Azrim <mirzaspc@gmail.com>`.

- **`TERMS.md`** — Terms of Service tuned to Aetherfin's actual posture. Key points:
  - Aetherfin is a *client*; the maintainer does not host, distribute, or operate any servers. All media content responsibility lives with the Jellyfin server you connect to.
  - Acceptable-use bans on accessing servers without permission, circumventing access controls, removing the MIT notice in forks.
  - No-warranty + limitation-of-liability sections consistent with the MIT license.
  - Governing-law clause kept jurisdiction-neutral.

- **`PRIVACY.md`** — plain-English privacy statement:
  - Leads with the headline: Aetherfin does not collect, transmit, or sell any data.
  - Table enumerating every piece of data the app handles, where it lives (secure_storage vs shared_preferences vs in-memory vs cache), and who sees it.
  - Explicit "What Aetherfin does NOT do" list (no analytics SDK, no ads, no Firebase / Sentry / Crashlytics, no telemetry, no background location).
  - Lists every Jellyfin endpoint the client touches and points readers at `lib/core/jellyfin/client.dart` so they can verify the claim.
  - Documents the four Android permissions (`INTERNET`, `ACCESS_NETWORK_STATE`, `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `WAKE_LOCK`) and why each is needed.

### Test plan

Docs-only change. `flutter analyze`, `flutter test`, and the APK build are unaffected.

### Author / contact info used

- Copyright holder: **Azrim** `<mirzaspc@gmail.com>` (provided by the user).
- Repository: <https://github.com/Aetherfin/mobile-app>.

### Notes

- The Terms / Privacy effective date is set to **May 11, 2026** — the date this PR was authored. Future changes should bump the date and add a brief note in the relevant section's revision log.
- The Privacy "What Aetherfin does NOT do" list is intentionally specific (Firebase Analytics, Mixpanel, Amplitude, Sentry, Crashlytics, etc.) so it's auditable. If we ever add any of these later, the policy and the commit that adds them must be updated together.
- TERMS §4 explicitly requires forks to (1) keep the MIT notice and (2) change their Application ID / name so end-users know they're not running upstream.