### PR TITLE
Fix Artwork crash on unbounded constraints (Infinity.round)

### DIFF
--- a/lib/widgets/artwork.dart
+++ b/lib/widgets/artwork.dart
@@ -28,9 +28,15 @@ class Artwork extends StatelessWidget {
   Widget build(BuildContext context) {
     final w = size;
     final h = height ?? size;
+    // `size` / `height` can come from `double.infinity` when Artwork
+    // is dropped into an unbounded constraint (Expanded, Flexible,
+    // ConstrainedBox with no max). `Infinity.round()` throws, so any
+    // memCache hint must be guarded.
+    final wFinite = w.isFinite ? w : null;
+    final hFinite = h.isFinite ? h : null;
     final placeholder = Container(
-      width: w,
-      height: h,
+      width: wFinite,
+      height: hFinite,
       decoration: BoxDecoration(
         borderRadius: radius,
         gradient: const LinearGradient(
@@ -50,19 +56,29 @@ class Artwork extends StatelessWidget {
     if (url == null || url!.isEmpty) {
       return Semantics(label: semanticLabel, child: placeholder);
     }
+    final dpr = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 2.0;
+    int? clampedCachePx(double? logicalPx) {
+      if (logicalPx == null) return null;
+      final physical = (logicalPx * dpr).round();
+      // Hard ceiling so a misconfigured giant artwork (e.g. 4096px
+      // wide page hero) doesn't decode an obscene bitmap.
+      if (physical <= 0) return null;
+      return physical > 1024 ? 1024 : physical;
+    }
+
     return ClipRRect(
       borderRadius: radius,
       child: SizedBox(
-        width: w,
-        height: h,
+        width: wFinite,
+        height: hFinite,
         child: CachedNetworkImage(
           imageUrl: url!,
           fit: fit,
           placeholder: (_, __) => placeholder,
           errorWidget: (_, __, ___) => placeholder,
           fadeInDuration: AfDurations.quick,
-          memCacheWidth: (w * 2).round(),
-          memCacheHeight: (h * 2).round(),
+          memCacheWidth: clampedCachePx(wFinite),
+          memCacheHeight: clampedCachePx(hFinite),
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Logcat from the user's device install of PR #5 surfaced a repeated:

```
Unsupported operation: Infinity or NaN toInt
#0  Artwork.build (package:aetherfin/widgets/artwork.dart)
```

### Root cause

`Artwork` computed:

```dart
memCacheWidth: (w * 2).round(),
memCacheHeight: (h * 2).round(),
```

When `Artwork` is dropped inside an unbounded constraint (`Expanded`, `Flexible`, `ConstrainedBox` with no finite max) the default `size` of `56` is overridden by the parent to `double.infinity`. `Infinity.round()` throws, the build aborts, and the network image is never resolved — the user sees the indigo placeholder forever for that tile.

### Fix

- Guard with `isFinite` before passing to `round()`.
- When finite, use the actual device pixel ratio from `MediaQuery` (instead of a hardcoded `2x` multiplier).
- Clamp the cache hint at **1024 px** so a 4096 px hero doesn't decode a giant bitmap.
- When infinite, omit the cache hint entirely and let `CachedNetworkImage` size itself from the layout constraints.
- Same `isFinite ? value : null` treatment for the placeholder `Container`'s width / height.

### Test plan

- `flutter analyze --no-fatal-infos` → 0 errors / 0 warnings (verified locally).
- `flutter test` → 6/6 pass.
- New split APK build will be dispatched after merge so the user can confirm the indigo-placeholder regression is gone.

### Note on architecture model

This is purely a client-side rendering bug. Server contract (CLAUDE.md §1.1) is unchanged — Jellyfin is still the file source, Aetherfin is still the player. No HTTP behaviour is touched.