### PR TITLE
PR 1: security + correctness review fixes (S1-S7, B1-B8, B14)

### DIFF
--- a/lib/core/audio/jellyfin_playback_reporter.dart
+++ b/lib/core/audio/jellyfin_playback_reporter.dart
@@ -32,6 +32,12 @@ class JellyfinPlaybackReporter {
   StreamSubscription<bool>? _playingSub;
   Timer? _progressTimer;
   String? _lastReportedTrackId;
+  // dispose() must NOT send a `Stopped` ping when the reporter is being
+  // torn down purely because the ProviderScope rebuilt around a still-
+  // playing track — otherwise Jellyfin's activity feed flips to "stopped"
+  // while audio keeps coming out the speaker. Set to false on every
+  // intentional teardown (audio service stops, sign-out, app close).
+  bool _shouldStopOnDispose = false;
 
   JellyfinPlaybackReporter(this._player, this._clientGetter) {
     _trackSub = _player.currentTrackStream.listen(_onTrackChanged);
@@ -153,6 +159,10 @@ class JellyfinPlaybackReporter {
     _stopProgressTimer();
     final trackId = _lastReportedTrackId;
     if (trackId == null) return;
+    // Only emit a Stopped on dispose if it was explicitly requested
+    // (sign-out, audio handler tear-down) — a Riverpod scope rebuild
+    // around a still-playing track must NOT flip the activity feed.
+    if (!_shouldStopOnDispose) return;
     final client = _clientGetter();
     if (client == null) return;
     final position = _player.position;
@@ -167,5 +177,13 @@ class JellyfinPlaybackReporter {
       // ignore: avoid_print
       print('aetherfin:error stack: $stack');
     }
+  }
+
+  /// Call before [dispose] when the caller WANTS a final Stopped ping
+  /// to be sent (sign-out, app close, queue cleared). Default is to
+  /// keep the active session open so the activity feed isn't trashed
+  /// by spurious teardowns.
+  void requestStopOnDispose() {
+    _shouldStopOnDispose = true;
   }
 }

--- a/lib/core/audio/play_actions.dart
+++ b/lib/core/audio/play_actions.dart
@@ -29,13 +29,19 @@ class PlayActions {
       return 'about:blank';
     }
 
-    ref.read(currentTrackProvider.notifier).state = tracks[startIndex];
+    // Clamp the caller-supplied index so a stale UI snapshot can't push us
+    // into a RangeError when we look up `tracks[startIndex]` below.
+    final safeIndex = startIndex < 0
+        ? 0
+        : (startIndex >= tracks.length ? tracks.length - 1 : startIndex);
+    ref.read(currentTrackProvider.notifier).state = tracks[safeIndex];
     if (client != null) {
       try {
         await svc.playQueue(
           tracks,
-          startIndex: startIndex,
+          startIndex: safeIndex,
           resolveStreamUrl: resolveStreamUrl,
+          streamHeaders: client.authHeaders,
         );
       } catch (e, stack) {
         // Leave the queue staged so the mini-player keeps the track

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -90,11 +90,25 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
   double get speed => _player.speed;
 
   /// Replace the queue with [tracks] and start playback at [startIndex].
+  ///
+  /// [streamHeaders] are attached to every `AudioSource.uri` so the
+  /// Jellyfin Authorization header rides on each stream request instead
+  /// of being embedded as `?api_key=…` in the URL (where it would leak to
+  /// the server's access log and any logcat-grepping app on the device).
   Future<void> playQueue(
     List<AfTrack> tracks, {
     int startIndex = 0,
     required String Function(AfTrack track) resolveStreamUrl,
+    Map<String, String> streamHeaders = const {},
   }) async {
+    if (tracks.isEmpty) return;
+    // Clamp the caller-supplied index so a stale UI cannot crash playback
+    // with a RangeError on the line `tracks[startIndex]` below.
+    final safeIndex = startIndex < 0
+        ? 0
+        : (startIndex >= tracks.length ? tracks.length - 1 : startIndex);
+    final previousIndex = _currentIndex;
+    final previousQueue = List<AfTrack>.from(_trackQueue);
     _trackQueue
       ..clear()
       ..addAll(tracks);
@@ -103,36 +117,44 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
     final sources = tracks
         .map((t) => AudioSource.uri(
               Uri.parse(resolveStreamUrl(t)),
+              headers: streamHeaders.isEmpty ? null : streamHeaders,
               tag: _mediaItemFor(t),
             ))
         .toList();
-    final startTrack = tracks[startIndex];
+    final startTrack = tracks[safeIndex];
     // Pre-set _currentIndex BEFORE setAudioSource so the currentIndexStream
     // listener's dedupe (`if (idx == _currentIndex) return;`) suppresses
     // the spurious emit that fires immediately after the source is set —
     // we drive the initial onTrackChanged + mediaItem broadcast ourselves
     // below so the UI / playback reporter see the new track before audio
     // even starts loading.
-    _currentIndex = startIndex;
+    _currentIndex = safeIndex;
     mediaItem.add(_mediaItemFor(startTrack));
     _trackController.add(startTrack);
     // ignore: avoid_print
     print(
       'aetherfin:data playQueue source=live size=${tracks.length} '
-      'startIndex=$startIndex first="${startTrack.title}" '
-      'url="${resolveStreamUrl(startTrack)}"',
+      'startIndex=$safeIndex first="${startTrack.title}"',
     );
     onTrackChanged?.call(startTrack);
     try {
       await _player.setAudioSource(
         ConcatenatingAudioSource(children: sources),
-        initialIndex: startIndex,
+        initialIndex: safeIndex,
       );
     } on Object catch (e, stack) {
       // ignore: avoid_print
       print('aetherfin:audio setAudioSource failed: $e');
       // ignore: avoid_print
       print('aetherfin:audio stack: $stack');
+      // Revert the optimistic queue + index update so the UI doesn't
+      // keep claiming a track is loaded that we couldn't actually wire up.
+      _trackQueue
+        ..clear()
+        ..addAll(previousQueue);
+      _currentIndex = previousIndex;
+      queue.add(previousQueue.map(_mediaItemFor).toList());
+      _queueController.add(List.unmodifiable(_trackQueue));
       rethrow;
     }
     try {

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
 
 import 'models/items.dart';
 import 'models/library.dart';
@@ -16,13 +17,15 @@ class JellyfinClient {
   final String? userId;
   final String deviceId;
   final Dio _dio;
+  final MemCacheStore _cacheStore;
 
   JellyfinClient({
     required this.server,
     required this.deviceId,
     this.accessToken,
     this.userId,
-  }) : _dio = Dio(BaseOptions(
+  })  : _cacheStore = MemCacheStore(maxSize: 20 * 1024 * 1024, maxEntrySize: 1 * 1024 * 1024),
+        _dio = Dio(BaseOptions(
           // Trailing slash is REQUIRED so Dio's Uri.resolve preserves the
           // server's base path (e.g. https://example.com/jellyfin/). All
           // paths below are written WITHOUT a leading slash for the same
@@ -64,47 +67,104 @@ class JellyfinClient {
     _dio.interceptors.add(
       DioCacheInterceptor(
         options: CacheOptions(
-          store: MemCacheStore(),
+          store: _cacheStore,
           policy: CachePolicy.request,
           maxStale: const Duration(minutes: 5),
           priority: CachePriority.normal,
         ),
       ),
     );
-    // Log every request + response to logcat so we can see exactly what
-    // bytes go on the wire when debugging Jellyfin's 500 / 403 / etc.
-    // The Authorization header value is redacted to avoid leaking tokens.
-    _dio.interceptors.add(
-      InterceptorsWrapper(
-        onRequest: (options, handler) {
-          final redactedHeaders = Map<String, dynamic>.from(options.headers)
-            ..updateAll((k, v) =>
-                k.toLowerCase().contains('auth') ? '<redacted>' : v);
-          // ignore: avoid_print
-          print('aetherfin:http → ${options.method} ${options.uri}');
-          // ignore: avoid_print
-          print('aetherfin:http headers: $redactedHeaders');
-          // For auth-sensitive endpoints, redact the body too.
-          final isAuth = options.uri.path.toLowerCase().contains('authenticate');
-          // ignore: avoid_print
-          print('aetherfin:http body: '
-              '${isAuth ? '<redacted ${options.data is Map ? (options.data as Map).keys.toList() : options.data.runtimeType}>' : options.data}');
-          handler.next(options);
-        },
-        onResponse: (response, handler) {
-          // ignore: avoid_print
-          print('aetherfin:http ← ${response.statusCode} '
-              '${response.requestOptions.method} ${response.requestOptions.uri}');
-          handler.next(response);
-        },
-        onError: (err, handler) {
-          // ignore: avoid_print
-          print('aetherfin:http ✕ ${err.response?.statusCode ?? '?'} '
-              '${err.requestOptions.method} ${err.requestOptions.uri}');
-          handler.next(err);
-        },
-      ),
-    );
+    // Debug-only HTTP trace. In release builds we skip these prints
+    // entirely so URLs, headers, and bodies never reach logcat where
+    // any app on the device with READ_LOGS could capture them.
+    if (kDebugMode) {
+      _dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            final redactedHeaders = Map<String, dynamic>.from(options.headers)
+              ..updateAll((k, v) =>
+                  k.toLowerCase().contains('auth') ? '<redacted>' : v);
+            // ignore: avoid_print
+            print('aetherfin:http → ${options.method} ${_redactUrl(options.uri)}');
+            // ignore: avoid_print
+            print('aetherfin:http headers: $redactedHeaders');
+            // For auth-sensitive endpoints, redact the body too.
+            final isAuth =
+                options.uri.path.toLowerCase().contains('authenticate');
+            // ignore: avoid_print
+            print('aetherfin:http body: '
+                '${isAuth ? '<redacted ${options.data is Map ? (options.data as Map).keys.toList() : options.data.runtimeType}>' : options.data}');
+            handler.next(options);
+          },
+          onResponse: (response, handler) {
+            // ignore: avoid_print
+            print('aetherfin:http ← ${response.statusCode} '
+                '${response.requestOptions.method} ${_redactUrl(response.requestOptions.uri)}');
+            handler.next(response);
+          },
+          onError: (err, handler) {
+            // ignore: avoid_print
+            print('aetherfin:http ✕ ${err.response?.statusCode ?? '?'} '
+                '${err.requestOptions.method} ${_redactUrl(err.requestOptions.uri)}');
+            handler.next(err);
+          },
+        ),
+      );
+    }
+  }
+
+  /// Headers callers can use to authenticate ad-hoc requests that bypass
+  /// the Dio instance — e.g. the audio source URI given to just_audio, or
+  /// a CachedNetworkImage that fetches an artwork-protected endpoint.
+  ///
+  /// Mirrors what the Dio client sends. Empty map if no token is set.
+  Map<String, String> get authHeaders {
+    final headers = <String, String>{
+      'User-Agent': 'Aetherfin/0.1.0 (Android)',
+      'Accept': '*/*',
+    };
+    if (accessToken != null) {
+      headers['Authorization'] = _buildAuthHeader(
+        deviceId: deviceId,
+        token: accessToken,
+        userId: userId,
+      );
+    }
+    return headers;
+  }
+
+  /// Strip credentials (api_key, X-Emby-Token) from a URL before it's
+  /// emitted to logcat. Defensive — we no longer add api_key to URLs,
+  /// but third-party endpoints or future code could.
+  static Uri _redactUrl(Uri uri) {
+    if (uri.queryParameters.isEmpty) return uri;
+    final scrubbed = <String, dynamic>{
+      for (final e in uri.queryParametersAll.entries)
+        e.key:
+            _isSensitiveParam(e.key) ? const ['<redacted>'] : e.value,
+    };
+    return uri.replace(queryParameters: scrubbed);
+  }
+
+  static bool _isSensitiveParam(String key) {
+    final k = key.toLowerCase();
+    return k == 'api_key' ||
+        k == 'apikey' ||
+        k == 'x-emby-token' ||
+        k == 'token';
+  }
+
+  /// Release in-memory cache (used on sign-out so cross-account leakage
+  /// is impossible).
+  void clearCache() {
+    _cacheStore.clean();
+  }
+
+  /// Free the underlying Dio resources. Call on sign-out so HTTP/2
+  /// connections + the cache buffer don't leak across accounts.
+  void close() {
+    _cacheStore.close();
+    _dio.close(force: true);
   }
 
   /// Build a Jellyfin Authorization header.
@@ -125,19 +185,31 @@ class JellyfinClient {
   }) {
     final parts = <String>[];
     if (userId != null && userId.isNotEmpty) {
-      parts.add('UserId="$userId"');
+      parts.add('UserId="${_escapeHeaderValue(userId)}"');
     }
     if (token != null && token.isNotEmpty) {
-      parts.add('Token="$token"');
+      parts.add('Token="${_escapeHeaderValue(token)}"');
     }
     parts.add('Client="Aetherfin"');
     parts.add('Device="Android"');
-    parts.add('DeviceId="$deviceId"');
+    parts.add('DeviceId="${_escapeHeaderValue(deviceId)}"');
     parts.add('Version="0.1.0"');
     final raw = 'MediaBrowser ${parts.join(", ")}';
     // Belt-and-braces: strip anything outside the 7-bit ASCII range so
     // unusual device names / pasted tokens can never break the parser.
     return raw.replaceAll(RegExp(r'[^\x00-\x7F]+'), '_');
+  }
+
+  /// Escape characters that would break Jellyfin's quoted-string parser
+  /// in the Authorization header. Specifically `"` and `\\` get escaped,
+  /// and `\r` / `\n` are dropped entirely so a malicious value cannot
+  /// inject extra header fields.
+  static String _escapeHeaderValue(String v) {
+    return v
+        .replaceAll('\\', r'\\')
+        .replaceAll('"', r'\"')
+        .replaceAll('\r', '')
+        .replaceAll('\n', '');
   }
 
   /// `GET /System/Info/Public` — used by mDNS resolution to confirm a
@@ -205,25 +277,29 @@ class JellyfinClient {
         'Accept': 'application/json',
       },
     ));
-    final res = await probe.get<List<dynamic>>('Users');
-    final users = (res.data ?? const []).cast<Map>();
-    final wanted = username.trim().toLowerCase();
-    for (final raw in users) {
-      final u = raw.cast<String, dynamic>();
-      final name = (u['Name'] as String?)?.trim() ?? '';
-      if (name.toLowerCase() == wanted) {
-        return JellyfinAuth(
-          server: server,
-          userId: u['Id'] as String,
-          userName: name,
-          accessToken: apiKey,
-        );
+    try {
+      final res = await probe.get<List<dynamic>>('Users');
+      final users = (res.data ?? const []).cast<Map>();
+      final wanted = username.trim().toLowerCase();
+      for (final raw in users) {
+        final u = raw.cast<String, dynamic>();
+        final name = (u['Name'] as String?)?.trim() ?? '';
+        if (name.toLowerCase() == wanted) {
+          return JellyfinAuth(
+            server: server,
+            userId: u['Id'] as String,
+            userName: name,
+            accessToken: apiKey,
+          );
+        }
       }
+      throw StateError(
+        'No user named "$username" on this server. '
+        'Available: ${users.map((u) => u['Name']).join(", ")}',
+      );
+    } finally {
+      probe.close(force: true);
     }
-    throw StateError(
-      'No user named "$username" on this server. '
-      'Available: ${users.map((u) => u['Name']).join(", ")}',
-    );
   }
 
   /// `GET /Users/{userId}/Views` — the list of libraries the user can see.
@@ -238,19 +314,6 @@ class JellyfinClient {
                   .toLowerCase(),
             ))
         .toList(growable: false);
-  }
-
-  /// Resolve an album/track/artist Primary image URL (delegates to Jellyfin's
-  /// `/Items/{id}/Images/Primary` endpoint with `maxWidth` and `quality` query
-  /// params for sane bandwidth).
-  String imageUrl(String itemId, {int maxWidth = 480, int quality = 90}) {
-    final qp = <String, String>{
-      'maxWidth': '$maxWidth',
-      'quality': '$quality',
-      if (accessToken != null) 'api_key': accessToken!,
-    };
-    final query = qp.entries.map((e) => '${e.key}=${e.value}').join('&');
-    return '${server.baseUrl}/Items/$itemId/Images/Primary?$query';
   }
 
   /// Build a streaming URL for a given track ID.
@@ -282,13 +345,24 @@ class JellyfinClient {
       'Static': 'true',
       'UserId': userId!,
       'DeviceId': deviceId,
-      if (accessToken != null) 'api_key': accessToken!,
       if (maxBitrateKbps != null)
         'MaxStreamingBitrate': '${maxBitrateKbps * 1000}',
       if (deviceProfileId != null) 'DeviceProfileId': deviceProfileId,
     };
-    final query = qp.entries.map((e) => '${e.key}=${e.value}').join('&');
-    return '${server.baseUrl}/Audio/$trackId/stream?$query';
+    final base = server.baseUrl.endsWith('/')
+        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
+        : server.baseUrl;
+    // Build via `Uri` so every value is URL-encoded — historically we hand
+    // -joined `$k=$v` pairs which silently mis-encoded tokens / IDs that
+    // contained `+`, `=`, `&`, or `/`. The token used to ride in this URL
+    // as `api_key=…`; it now travels in the Authorization header (see
+    // `authHeaders`) which a logcat-grepping attacker cannot recover.
+    return Uri.parse(base)
+        .replace(
+          path: '${Uri.parse(base).path}/Audio/$trackId/stream',
+          queryParameters: qp,
+        )
+        .toString();
   }
 
   /// `POST /Sessions/Playing` — tell the server a track just started.
@@ -987,7 +1061,14 @@ class JellyfinClient {
       'quality': '$quality',
       'tag': tag,
     };
-    final query = qp.entries.map((e) => '${e.key}=${e.value}').join('&');
-    return '${server.baseUrl}/Items/$itemId/Images/$imageType?$query';
+    final base = server.baseUrl.endsWith('/')
+        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
+        : server.baseUrl;
+    return Uri.parse(base)
+        .replace(
+          path: '${Uri.parse(base).path}/Items/$itemId/Images/$imageType',
+          queryParameters: qp,
+        )
+        .toString();
   }
 }

--- a/lib/core/jellyfin/discovery.dart
+++ b/lib/core/jellyfin/discovery.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:multicast_dns/multicast_dns.dart';
 
+import 'client.dart';
 import 'models/server.dart';
 
 /// Scans the local network for Jellyfin servers via mDNS.
@@ -58,7 +59,14 @@ class JellyfinDiscovery {
             );
             await for (final ip in ipStream) {
               if (completer.isCompleted) break;
-              final url = 'http://${ip.address.address}:${srv.port}';
+              final addr = ip.address.address;
+              final port = srv.port;
+              // Most home Jellyfin installs are plain-HTTP on the LAN,
+              // but some users front them with a reverse proxy on the
+              // same host. Probe HTTPS first (no cost when it 404s
+              // fast) so encrypted servers don't get downgraded to
+              // HTTP just because mDNS advertises the bare port.
+              final url = await _resolveBaseUrl(addr, port);
               if (seen.add(url)) {
                 yield JellyfinServer(
                   baseUrl: url,
@@ -77,6 +85,31 @@ class JellyfinDiscovery {
       ]);
     } finally {
       client.stop();
+    }
+  }
+
+  /// Pick the best scheme for the discovered host/port pair.
+  ///
+  /// We probe `https://host:port/System/Info/Public` with a short
+  /// connect timeout. Anything that completes (200 / 401 / 404 — all
+  /// count) means the port speaks TLS, so we keep https. On any TLS
+  /// handshake failure, refusal, or timeout we fall back to plain http
+  /// which is what mDNS advertises by default.
+  static Future<String> _resolveBaseUrl(String addr, int port) async {
+    final https = 'https://$addr:$port';
+    try {
+      final probe = JellyfinClient(
+        server: JellyfinServer(baseUrl: https, name: addr, isLocal: true),
+        deviceId: 'aetherfin-discovery-probe',
+      );
+      try {
+        await probe.publicInfo().timeout(const Duration(seconds: 2));
+        return https;
+      } finally {
+        probe.close();
+      }
+    } catch (_) {
+      return 'http://$addr:$port';
     }
   }
 }

--- a/lib/features/onboarding/sign_in_screen.dart
+++ b/lib/features/onboarding/sign_in_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -74,10 +75,15 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
         print('aetherfin:error url: ${e.requestOptions.uri}');
         // ignore: avoid_print
         print('aetherfin:error status: ${e.response?.statusCode}');
-        // ignore: avoid_print
-        print('aetherfin:error body: ${e.response?.data}');
-        // ignore: avoid_print
-        print('aetherfin:error headers: ${e.response?.headers.map}');
+        // Body + response headers can include cookies, server-side error
+        // messages, and full HTML 500 pages — only emit them in debug
+        // builds so a release-build logcat capture stays sanitized.
+        if (kDebugMode) {
+          // ignore: avoid_print
+          print('aetherfin:error body: ${e.response?.data}');
+          // ignore: avoid_print
+          print('aetherfin:error headers: ${e.response?.headers.map}');
+        }
       }
       // ignore: avoid_print
       print('aetherfin:error stack: $stack');
@@ -181,7 +187,10 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
               const SizedBox(height: AfSpacing.s12),
               TextField(
                 controller: _pass,
-                obscureText: !_useToken,
+                // Always obscure — both passwords and API tokens are
+                // sensitive secrets that should never be visible on a
+                // shoulder-surfed device.
+                obscureText: true,
                 autocorrect: false,
                 decoration: InputDecoration(
                   hintText: _useToken ? 'API token' : 'Password',

--- a/lib/features/search/search_screen.dart
+++ b/lib/features/search/search_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -20,12 +22,33 @@ class SearchScreen extends ConsumerStatefulWidget {
 
 class _SearchScreenState extends ConsumerState<SearchScreen> {
   final _controller = TextEditingController();
+  // Wait this long after the last keystroke before firing a request —
+  // matches Jellyfin's own web client (~250ms) and avoids one
+  // `/Users/{id}/Items?searchTerm=` per keystroke.
+  static const _debounce = Duration(milliseconds: 250);
+  Timer? _debounceTimer;
   String _query = '';
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
     _controller.dispose();
     super.dispose();
+  }
+
+  void _onChanged(String raw) {
+    _debounceTimer?.cancel();
+    // An empty query collapses back to the idle state — do that
+    // synchronously so the keyboard's clear-button feels instant.
+    if (raw.isEmpty) {
+      if (_query.isNotEmpty) setState(() => _query = '');
+      return;
+    }
+    _debounceTimer = Timer(_debounce, () {
+      if (!mounted) return;
+      if (_query == raw) return;
+      setState(() => _query = raw);
+    });
   }
 
   @override
@@ -52,7 +75,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                 hintText: 'Artists, albums, tracks…',
                 prefixIcon: Icon(Icons.search_rounded),
               ),
-              onChanged: (v) => setState(() => _query = v),
+              onChanged: _onChanged,
             ),
           ),
           const SizedBox(height: AfSpacing.s16),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app/app.dart';
 import 'core/audio/player_service.dart';
@@ -13,6 +14,14 @@ import 'core/jellyfin/auth_storage.dart';
 import 'core/jellyfin/models/server.dart';
 import 'design_tokens/tokens.dart';
 import 'state/providers.dart';
+
+/// Plain-prefs key for the fallback device ID used when the encrypted
+/// secure-storage keystore can't be reached. Persisting the fallback
+/// means even a permanently-broken keystore looks like the SAME device
+/// across launches instead of a fresh one (which would create a stale
+/// Jellyfin session per launch and trip the 500-on-AuthenticateByName
+/// described in CLAUDE.md §5.1).
+const _fallbackDeviceIdKey = 'aetherfin.deviceId.fallback.v1';
 
 /// Boot breadcrumb — every checkpoint prefixes with this so a single
 /// `adb logcat | grep aetherfin:boot` shows the full startup trace.
@@ -75,10 +84,12 @@ Future<void> main() async {
       print('aetherfin:error device id / auth load failed: $e');
       // ignore: avoid_print
       print('aetherfin:error stack: $stack');
-      // Last-ditch fallback so onboarding can still proceed. The cost is
-      // that this install will look like a new device to Jellyfin on
-      // every launch until secure storage starts working again.
-      deviceId = 'aetherfin-fallback-${DateTime.now().microsecondsSinceEpoch}';
+      // Last-ditch fallback so onboarding can still proceed. Persist
+      // the fallback ID to plain shared_preferences so it survives the
+      // next launch even when secure_storage stays broken — otherwise
+      // Jellyfin sees a new device on every launch and accumulates
+      // stale sessions (the known cause of `AuthenticateByName` 500s).
+      deviceId = await _loadOrCreateFallbackDeviceId();
       initialAuth = null;
     }
 
@@ -126,6 +137,39 @@ Future<void> main() async {
     // ignore: avoid_print
     print('aetherfin:error stack: $stack');
   });
+}
+
+/// Read or generate the persistent fallback device ID.
+///
+/// Only used when `flutter_secure_storage` is unreachable (corrupt
+/// keystore, brand-new device with no biometric setup, etc.). The ID
+/// lives in plain `shared_preferences` — not as secure as the encrypted
+/// store, but it's just a random opaque token (not a credential) and
+/// having it survive launches is far more important than hiding it.
+Future<String> _loadOrCreateFallbackDeviceId() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = prefs.getString(_fallbackDeviceIdKey);
+    if (existing != null && existing.isNotEmpty) {
+      _boot('fallback device id reused (len=${existing.length})');
+      return existing;
+    }
+    final fresh =
+        'aetherfin-fallback-${DateTime.now().microsecondsSinceEpoch}';
+    await prefs.setString(_fallbackDeviceIdKey, fresh);
+    _boot('fallback device id generated (len=${fresh.length})');
+    return fresh;
+  } catch (e, stack) {
+    // ignore: avoid_print
+    print('aetherfin:error fallback device id load failed: $e');
+    // ignore: avoid_print
+    print('aetherfin:error stack: $stack');
+    // shared_preferences itself is unavailable — pick a per-launch ID
+    // so the rest of the app still functions, even if Jellyfin sees a
+    // new device every time. This branch is essentially unreachable on
+    // a normal Android device.
+    return 'aetherfin-fallback-${DateTime.now().microsecondsSinceEpoch}';
+  }
 }
 
 Future<void> _warmUpAudio(AfPlayerService handler) async {

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -71,12 +71,22 @@ class AuthNotifier extends StateNotifier<JellyfinAuth?> {
   final AuthStorage _storage;
   AuthNotifier(this._storage, {JellyfinAuth? initial}) : super(initial);
 
+  /// Persist [auth] FIRST, then flip in-memory state.
+  ///
+  /// Previously we set `state = auth` before the storage write — if the
+  /// keystore was full / corrupted the user looked signed in but the
+  /// next app launch would silently kick them back to onboarding. By
+  /// failing loudly here the sign-in screen surfaces the error instead,
+  /// and a successful flip implies the secret already hit disk.
   Future<void> save(JellyfinAuth auth) async {
-    state = auth;
     await _storage.save(auth);
+    state = auth;
   }
 
   Future<void> clear() async {
+    // The Jellyfin client provider listens to this state and tears
+    // itself down (HTTP cache + connection pool) via `ref.onDispose`
+    // when `state` flips to null.
     state = null;
     await _storage.clear();
   }
@@ -95,12 +105,17 @@ final jellyfinClientProvider = Provider<JellyfinClient?>((ref) {
   _logData('jellyfinClient',
       source: 'live',
       extra: 'server=${auth.server.baseUrl} user=${auth.userName}');
-  return JellyfinClient(
+  final client = JellyfinClient(
     server: auth.server,
     deviceId: ref.watch(deviceIdProvider),
     accessToken: auth.accessToken,
     userId: auth.userId,
   );
+  // When auth flips (sign-out, account switch) the provider rebuilds —
+  // tear down the old client so its HTTP cache + connection pool don't
+  // leak across accounts.
+  ref.onDispose(client.close);
+  return client;
 });
 
 /// ─────────────────────────────────────────────────────────────────────────

--- a/lib/widgets/waveform.dart
+++ b/lib/widgets/waveform.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 
 import '../design_tokens/tokens.dart';
@@ -227,7 +228,9 @@ class _VisualiserPainter extends CustomPainter {
   bool shouldRepaint(_VisualiserPainter old) =>
       old.t != t ||
       old.progress != progress ||
-      old.peaks != peaks ||
+      // `peaks` is a fresh list on every parent rebuild; compare values,
+      // not the reference, or we repaint on every frame for no reason.
+      !listEquals(old.peaks, peaks) ||
       old.playedColor != playedColor ||
       old.unplayedColor != unplayedColor ||
       old.animate != animate;

--- a/test/jellyfin_client_test.dart
+++ b/test/jellyfin_client_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:aetherfin/core/jellyfin/client.dart';
+import 'package:aetherfin/core/jellyfin/models/server.dart';
+
+JellyfinClient _client({
+  String baseUrl = 'http://srv:8096',
+  String? token,
+  String? userId,
+}) {
+  return JellyfinClient(
+    server: JellyfinServer(baseUrl: baseUrl, name: 'srv'),
+    deviceId: 'dev-1',
+    accessToken: token,
+    userId: userId,
+  );
+}
+
+void main() {
+  group('trackStreamUrl', () {
+    test('omits api_key — auth rides on Authorization header now', () {
+      final url = _client(token: 't-abc', userId: 'u-1')
+          .trackStreamUrl('track-1', maxBitrateKbps: 320);
+      expect(url.contains('api_key='), isFalse,
+          reason: 'Token must not be embedded in the URL.');
+      expect(url.contains('Static=true'), isTrue);
+      expect(url.contains('Audio/track-1/stream'), isTrue);
+      expect(url.contains('MaxStreamingBitrate=320000'), isTrue);
+    });
+
+    test('URL-encodes path + query values', () {
+      // Track IDs with `+` `=` `&` are unusual but exist in some libraries.
+      final url = _client(userId: 'a+b=c&d').trackStreamUrl('xyz');
+      final uri = Uri.parse(url);
+      // The decoded userId must round-trip exactly through `queryParameters`.
+      expect(uri.queryParameters['UserId'], 'a+b=c&d');
+      // Raw query string must NOT contain the unencoded `+` / `=` / `&`
+      // in the middle of the value.
+      expect(uri.query.contains('UserId=a+b=c'), isFalse,
+          reason: 'Plus / equals must be percent-encoded.');
+    });
+
+    test('preserves nested base path (e.g. /jellyfin)', () {
+      final url = _client(baseUrl: 'https://host.tld/jellyfin', userId: 'u-1')
+          .trackStreamUrl('track-2');
+      expect(url.startsWith('https://host.tld/jellyfin/Audio/track-2/stream'),
+          isTrue,
+          reason: 'Server-relative base path must survive Uri.replace.');
+    });
+
+    test('handles trailing slash on baseUrl', () {
+      final url = _client(baseUrl: 'https://host.tld/', userId: 'u-1')
+          .trackStreamUrl('track-3');
+      expect(url.startsWith('https://host.tld/Audio/track-3/stream'), isTrue);
+      expect(url.contains('//Audio'), isFalse,
+          reason: 'Must not produce `//Audio` from a trailing slash.');
+    });
+  });
+
+  group('authHeaders', () {
+    test('returns Authorization with all required fields when authed', () {
+      final headers =
+          _client(token: 't-abc', userId: 'u-1').authHeaders;
+      final auth = headers['Authorization'] ?? '';
+      expect(auth.startsWith('MediaBrowser '), isTrue);
+      expect(auth.contains('UserId="u-1"'), isTrue);
+      expect(auth.contains('Token="t-abc"'), isTrue);
+      expect(auth.contains('Client="Aetherfin"'), isTrue);
+      expect(auth.contains('Device="Android"'), isTrue);
+      expect(auth.contains('DeviceId="dev-1"'), isTrue);
+      expect(auth.contains('Version="0.1.0"'), isTrue);
+    });
+
+    test('omits Authorization entirely when no token', () {
+      final headers = _client().authHeaders;
+      expect(headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('escapes quote / backslash / CR / LF in user-supplied values', () {
+      // A malicious server returns a userId with `"` so the attacker
+      // could inject Token="…", Client="evil" if we didn't escape.
+      final auth = _client(token: 'safe', userId: r'evil",X="y')
+          .authHeaders['Authorization']!;
+      // Must not introduce a real `X="y` field — the injection should be
+      // neutralized by escaping the inner quotes.
+      expect(auth.contains(', X="y'), isFalse);
+      // Newlines must be stripped so header smuggling is impossible.
+      final crlf = _client(token: "abc\r\nX-Evil: hi", userId: 'u')
+          .authHeaders['Authorization']!;
+      expect(crlf.contains('\n'), isFalse);
+      expect(crlf.contains('\r'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First of two PRs implementing the approved code review. Focused on security (logging, token leakage, header smuggling) and correctness (URL encoding, debouncing, repaint comparisons, state-write ordering, crash guards). No user-visible behavior change on the happy path — search will feel snappier, the visualiser repaint stops thrashing, and sign-in errors that previously vanished into logcat now surface in the form field.

PR 2 will follow with performance + polish fixes (P1, P2, Q1, Q3, Q4, B9–B13).

### Security (S-series)

- **S1** `lib/core/jellyfin/client.dart` — Gate the Dio request / response trace on `kDebugMode` and scrub `api_key` / `x-emby-token` from URLs before logging. Release builds no longer print URLs, headers, or bodies to logcat where any app with `READ_LOGS` could pick them up.
- **S2** `client.dart` + `core/audio/player_service.dart` + `core/audio/play_actions.dart` — Move the Jellyfin access token from `?api_key=…` in the stream URL to the `Authorization` header via the new `authHeaders` getter, threaded through `AudioSource.uri(headers: …)`. Tokens no longer end up in the Jellyfin server's access log or in `cached_network_image`'s on-disk cache key.
- **S3** `client.dart` — Escape `"`, `\\`, `\r`, `\n` in user-supplied values (`userId`, `token`, `deviceId`) before substituting them into the `MediaBrowser` Authorization header. Prevents header smuggling / field injection from a malicious server.
- **S4** `lib/features/onboarding/sign_in_screen.dart` — Gate the `DioException` body and response-headers prints on `kDebugMode`. Status code + URL still logged in release.
- **S5** `lib/core/jellyfin/discovery.dart` — Probe `https://addr:port/System/Info/Public` (2 s timeout) before falling back to `http://`. mDNS-discovered TLS servers no longer get silently downgraded just because mDNS advertises the bare port.
- **S6** `client.dart` — Bound `MemCacheStore` (20 MB total, 1 MB per entry) and tear it down via `ref.onDispose` on auth flip so the cache + Dio connection pool don't leak across accounts.
- **S7** `lib/main.dart` — Persist the fallback device ID to `shared_preferences` so a broken secure-storage keystore no longer makes every launch look like a new device (which previously accumulated stale Jellyfin sessions and is one root cause of the `AuthenticateByName` 500 documented in CLAUDE.md §5.1).

### Correctness (B-series)

- **B1** `client.dart` — Build stream + image URLs via `Uri.replace(queryParameters: …)` so values containing `+ = & /` are percent-encoded. Manual `$k=$v` concatenation removed.
- **B2** `lib/features/search/search_screen.dart` — 250 ms keystroke debounce; empty query collapses synchronously so the keyboard's clear button stays responsive. Cuts ~5 requests/second to 1 per pause.
- **B3** `lib/widgets/waveform.dart` — Use `listEquals` for `peaks` comparison in `_VisualiserPainter.shouldRepaint`. Previously reference-equal lists forced a repaint every frame.
- **B4** `lib/state/providers.dart` — `AuthNotifier.save` now awaits the secure-storage write before flipping in-memory state. A storage failure surfaces on the sign-in screen instead of leaving the user appearing signed in for one frame and silently signed out on next launch.
- **B5** `client.dart` — `authenticateWithApiKey` closes its temp Dio probe in `finally` so HTTP/2 connections + read buffers don't leak per attempt.
- **B6** `player_service.dart` — `setAudioSource` failure now reverts the optimistic `_currentIndex`, `_trackQueue`, and queue broadcast so the UI doesn't keep claiming a track is loaded that never connected.
- **B7** `player_service.dart` + `play_actions.dart` — Clamp `startIndex` to `[0, tracks.length - 1]` before indexing. A stale UI snapshot can no longer throw `RangeError`.
- **B8** `lib/core/audio/jellyfin_playback_reporter.dart` — `dispose()` no longer sends a phantom `Stopped` ping unless `requestStopOnDispose()` was called. ProviderScope rebuilds around a still-playing track no longer flip the Jellyfin activity feed to stopped while audio plays on.
- **B14** `sign_in_screen.dart` — Password field always obscured; toggling to API-token mode no longer reveals the previously-typed password.

### Tests

- New `test/jellyfin_client_test.dart` (7 cases) covers `trackStreamUrl` token redaction, query / path encoding, nested base path (`/jellyfin`), trailing-slash handling, `authHeaders` shape, and header-injection escaping.
- `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings (48 infos, same as baseline).
- `flutter test` — **13/13 pass**.

## Review & Testing Checklist for Human

The S2 token-via-header change is the highest-risk part of this PR because it changes the wire format for every audio stream request. Everything else is local / well-covered by the new unit tests.

- [ ] **S2 stream playback works against your Jellyfin server.** Sign in, queue an album, and verify that:
    - Audio plays end-to-end (start, mid-track seek, next track).
    - The Jellyfin "Active Devices" / Dashboard widget shows you as the active session (proves `Authorization` header is being accepted).
    - `adb logcat -s flutter` no longer shows `api_key=` anywhere in `aetherfin:http →` lines.
- [ ] **S2 + S6 sign-out / sign-in cycle.** Sign out, sign back in (same account or a different one) and confirm a fresh stream still starts. Confirms the per-account client teardown in `jellyfinClientProvider`'s `ref.onDispose` doesn't strand the next client.
- [ ] **B4 sign-in error surfacing.** Hard to reproduce without a broken keystore, but eyeball that the sign-in screen still navigates to `/home` on success (the save-before-state-flip change preserves this).
- [ ] **B7 clamp.** Quickly tap an album row from `Library → Songs` while a long list is still loading. Should never throw `RangeError` in logcat.
- [ ] **B14 password obscuration.** On the sign-in screen, type a password, then flip the "Use API token instead" switch, then flip it back — the field must stay obscured at every step.

### Notes

- `lib/core/jellyfin/client.dart` had a dead `imageUrl()` helper that pasted `api_key` into the URL but was never called (real image URLs go through `_buildImageUrl`, which doesn't include `api_key`). I removed it as part of S2.
- The unused `dio_cache_interceptor` cache is now bounded and tied to the provider lifecycle, but I did NOT widen its scope or change its hit policy.
- `AudioSource.uri(headers: …)` is `just_audio`'s standard mechanism for per-stream auth headers; no additional native config needed.

CI verifies build + analyze + test on each push; I'll watch it and share the result.