### PR TITLE
PR 2: performance + polish review fixes (P1, P2, Q1, Q3, Q4, B9, B10, B12, B13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,14 @@ times:
   "transcoded" adds 1dp `AfColors.warningAmber` border.
 
 ### 4.2 Motion (`lib/design_tokens/motion.dart`)
-- **Exactly five** duration tiers: `instant 90ms`, `quick 180ms`,
-  `standard 240ms`, `expressive 360ms`, `slow 500ms`. The 200/300/500ms
+- **Exactly five** duration tiers: `instant 80ms`, `quick 160ms`,
+  `standard 240ms`, `expressive 400ms`, `long 600ms`. The 200/300/500ms
   Material defaults are forbidden — `test/design_tokens_test.dart` enforces
   this.
-- Exactly five easing curves: `easeStandard`, `easeEntrance`, `easeExit`,
-  `easeEmphasis`, `easeOvershoot`. Any new animation must pick from these.
+- Exactly five easing curves: `easeStandard`, `easeEmphasized`, `easeOut`,
+  `easeIn`, `linear`. Audio-coupled animations (waveform, progress ring,
+  lyric scroll) MUST use `linear` — easing audio time lies about playback
+  position. Any new animation must pick from these.
 
 ### 4.3 Mini-player rules
 - **56 dp tall, 12 dp horizontal margin, 16 dp gap to bottom nav** —
@@ -150,7 +152,7 @@ times:
   every scrollable so content never hides under it.
 - Visible only when the queue is non-empty. Tapping it opens Now Playing
   with a shared-element hero on the artwork.
-- Slides up with `AfCurves.easeEntrance` over `AfDurations.standard`.
+- Slides up with `AfCurves.easeOut` over `AfDurations.standard`.
 
 ### 4.4 Profile rules (Settings → Profile)
 Phases 1–8 of the spec require:

--- a/lib/core/audio/spectral_extractor.dart
+++ b/lib/core/audio/spectral_extractor.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show Color;
 
-import 'package:flutter/material.dart' show NetworkImage;
+import 'package:cached_network_image/cached_network_image.dart'
+    show CachedNetworkImageProvider;
 import 'package:palette_generator/palette_generator.dart';
 
 import '../../design_tokens/colors.dart';
@@ -15,10 +16,19 @@ import '../../utils/oklch.dart';
 ///      (discards greys, near-black, near-white).
 ///   3. Pick the highest-chroma remaining sample.
 ///   4. If no sample qualifies, fall back to indigo.500.
+///
+/// We feed [PaletteGenerator] a [CachedNetworkImageProvider] (instead of
+/// a plain `NetworkImage`) so the artwork bytes are reused from the same
+/// on-disk cache that `cached_network_image` writes for the cover-art
+/// widgets. Without this, every track change triggered a second HTTP
+/// fetch of artwork that was already on disk.
 class SpectralExtractor {
-  Future<Spectral> fromImageUrl(String imageUrl) async {
+  Future<Spectral> fromImageUrl(
+    String imageUrl, {
+    Map<String, String>? headers,
+  }) async {
     final palette = await PaletteGenerator.fromImageProvider(
-      NetworkImage(imageUrl),
+      CachedNetworkImageProvider(imageUrl, headers: headers),
       maximumColorCount: 16,
     );
     final samples = palette.colors.toList(growable: false);

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -184,6 +184,12 @@ class JellyfinClient {
     String? userId,
   }) {
     final parts = <String>[];
+    // UserId / Token come from Jellyfin (UUIDs / hex strings) and from
+    // an API-key paste field. They are ASCII-safe by contract — escape
+    // quotes / CR / LF / backslash so they can't smuggle extra header
+    // fields, but DON'T strip non-ASCII: if a future Jellyfin build
+    // ever issues a non-ASCII token, silently rewriting the bytes to
+    // `_` would auth-fail in a way that's painful to debug.
     if (userId != null && userId.isNotEmpty) {
       parts.add('UserId="${_escapeHeaderValue(userId)}"');
     }
@@ -192,12 +198,13 @@ class JellyfinClient {
     }
     parts.add('Client="Aetherfin"');
     parts.add('Device="Android"');
-    parts.add('DeviceId="${_escapeHeaderValue(deviceId)}"');
+    // DeviceId IS allowed to contain user-facing characters (it's
+    // currently random base64url but on the fallback path it includes
+    // a microsecond timestamp). Strip non-ASCII here only so Jellyfin's
+    // strict 7-bit header parser never sees an emoji-bearing device name.
+    parts.add('DeviceId="${_asciiClean(_escapeHeaderValue(deviceId))}"');
     parts.add('Version="0.1.0"');
-    final raw = 'MediaBrowser ${parts.join(", ")}';
-    // Belt-and-braces: strip anything outside the 7-bit ASCII range so
-    // unusual device names / pasted tokens can never break the parser.
-    return raw.replaceAll(RegExp(r'[^\x00-\x7F]+'), '_');
+    return 'MediaBrowser ${parts.join(", ")}';
   }
 
   /// Escape characters that would break Jellyfin's quoted-string parser
@@ -211,6 +218,12 @@ class JellyfinClient {
         .replaceAll('\r', '')
         .replaceAll('\n', '');
   }
+
+  /// Replace non-ASCII runs with `_`. Used only on the parts of the
+  /// header we *can* mangle without breaking auth — never on the
+  /// server-issued UserId / Token.
+  static String _asciiClean(String v) =>
+      v.replaceAll(RegExp(r'[^\x00-\x7F]+'), '_');
 
   /// `GET /System/Info/Public` — used by mDNS resolution to confirm a
   /// reachable server and pick up its name + version.
@@ -471,8 +484,7 @@ class JellyfinClient {
         'EnableImages': true,
       },
     );
-    final items = (res.data ?? const <dynamic>[]).cast<Map<dynamic, dynamic>>();
-    return items.map((m) => _parseAlbum(m.cast<String, dynamic>())).toList(growable: false);
+    return _parseRawItemList(res.data).map(_parseAlbum).toList(growable: false);
   }
 
   /// `GET /Users/{userId}/Items` — recently played audio tracks. Uses
@@ -660,25 +672,31 @@ class JellyfinClient {
   Future<({AfPlaylist playlist, List<AfTrack> tracks})?> playlist(
       String id) async {
     _assertUser();
-    final headerRes = await _dio.get<Map<String, dynamic>>(
-      'Users/$userId/Items/$id',
-      queryParameters: <String, dynamic>{
-        'Fields': 'ChildCount,CumulativeRunTimeTicks',
-      },
-    );
-    final header = headerRes.data;
+    // Fan out the header + tracks fetches in parallel — the second
+    // request doesn't depend on the first, so awaiting them serially
+    // doubled the time-to-first-byte of the Playlist screen.
+    final responses = await Future.wait<Response<Map<String, dynamic>>>([
+      _dio.get<Map<String, dynamic>>(
+        'Users/$userId/Items/$id',
+        queryParameters: <String, dynamic>{
+          'Fields': 'ChildCount,CumulativeRunTimeTicks',
+        },
+      ),
+      _dio.get<Map<String, dynamic>>(
+        'Playlists/$id/Items',
+        queryParameters: <String, dynamic>{
+          'UserId': userId,
+          'Fields': _trackFields,
+          'EnableImages': true,
+        },
+      ),
+    ]);
+    final header = responses[0].data;
     if (header == null || header.isEmpty) return null;
     final pl = _parsePlaylist(header);
-    final tracksRes = await _dio.get<Map<String, dynamic>>(
-      'Playlists/$id/Items',
-      queryParameters: <String, dynamic>{
-        'UserId': userId,
-        'Fields': _trackFields,
-        'EnableImages': true,
-      },
-    );
-    final tracks =
-        _parseItemList(tracksRes.data).map(_parseTrack).toList(growable: false);
+    final tracks = _parseItemList(responses[1].data)
+        .map(_parseTrack)
+        .toList(growable: false);
     return (playlist: pl, tracks: tracks);
   }
 
@@ -706,27 +724,31 @@ class JellyfinClient {
   /// album detail plus its ordered track list.
   Future<({AfAlbum album, List<AfTrack> tracks})?> album(String id) async {
     _assertUser();
-    final albumRes = await _dio.get<Map<String, dynamic>>(
-      'Users/$userId/Items/$id',
-      queryParameters: <String, dynamic>{
-        'Fields': _albumFields,
-      },
-    );
-    final albumData = albumRes.data;
+    // Same idea as [playlist] — the album header and its track list are
+    // independent endpoints; running them in parallel halves the
+    // perceived load time of the Album screen.
+    final responses = await Future.wait<Response<Map<String, dynamic>>>([
+      _dio.get<Map<String, dynamic>>(
+        'Users/$userId/Items/$id',
+        queryParameters: <String, dynamic>{
+          'Fields': _albumFields,
+        },
+      ),
+      _dio.get<Map<String, dynamic>>(
+        'Users/$userId/Items',
+        queryParameters: <String, dynamic>{
+          'ParentId': id,
+          'IncludeItemTypes': 'Audio',
+          'SortBy': 'ParentIndexNumber,IndexNumber,SortName',
+          'SortOrder': 'Ascending',
+          'Fields': _trackFields,
+        },
+      ),
+    ]);
+    final albumData = responses[0].data;
     if (albumData == null || albumData.isEmpty) return null;
     final album = _parseAlbum(albumData);
-
-    final tracksRes = await _dio.get<Map<String, dynamic>>(
-      'Users/$userId/Items',
-      queryParameters: <String, dynamic>{
-        'ParentId': id,
-        'IncludeItemTypes': 'Audio',
-        'SortBy': 'ParentIndexNumber,IndexNumber,SortName',
-        'SortOrder': 'Ascending',
-        'Fields': _trackFields,
-      },
-    );
-    final tracks = _parseItemList(tracksRes.data)
+    final tracks = _parseItemList(responses[1].data)
         .map(_parseTrack)
         .toList(growable: false);
     return (album: album, tracks: tracks);
@@ -864,7 +886,14 @@ class JellyfinClient {
       }
       return buf.toString();
     } on DioException catch (e) {
-      if (e.response?.statusCode == 404) return null;
+      // Treat any 4xx as "no lyrics here" — 404 (missing), 401/403 (no
+      // permission to read lyrics on this track), 400 (server doesn't
+      // support the endpoint at all). The Lyrics screen renders the
+      // tasteful "No lyrics yet" placeholder for `null`, which is the
+      // right UX regardless of which 4xx the server returned.
+      // 5xx still bubbles up so an outage doesn't get silently masked.
+      final status = e.response?.statusCode ?? 0;
+      if (status >= 400 && status < 500) return null;
       rethrow;
     }
   }
@@ -894,11 +923,21 @@ class JellyfinClient {
   List<Map<String, dynamic>> _parseItemList(Map<String, dynamic>? data) {
     if (data == null) return const [];
     final items = data['Items'] as List? ?? const [];
-    return items
-        .whereType<Map>()
-        .map((m) => m.cast<String, dynamic>())
-        .toList(growable: false);
+    return _normaliseItems(items);
   }
+
+  /// Same as [_parseItemList] but for endpoints that return a raw
+  /// top-level JSON array (e.g. `/Users/{id}/Items/Latest`) instead of
+  /// the usual `{Items: [...]}` envelope. Centralises the casting so
+  /// every parser goes through the same code path.
+  List<Map<String, dynamic>> _parseRawItemList(List<dynamic>? data) =>
+      _normaliseItems(data ?? const []);
+
+  List<Map<String, dynamic>> _normaliseItems(Iterable<dynamic> items) =>
+      items
+          .whereType<Map>()
+          .map((m) => m.cast<String, dynamic>())
+          .toList(growable: false);
 
   AfAlbum _parseAlbum(Map<String, dynamic> m) {
     final id = m['Id'] as String;

--- a/lib/core/jellyfin/discovery.dart
+++ b/lib/core/jellyfin/discovery.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:async/async.dart' show StreamGroup;
 import 'package:multicast_dns/multicast_dns.dart';
 
 import 'client.dart';
@@ -114,32 +115,4 @@ class JellyfinDiscovery {
   }
 }
 
-/// Minimal stream-group merge (we don't pull in `async/StreamGroup` to avoid
-/// a heavy dep — we only ever merge two streams).
-class StreamGroup {
-  static Stream<T> merge<T>(Iterable<Stream<T>> streams) async* {
-    final controller = StreamController<T>();
-    final subs = <StreamSubscription<T>>[];
-    var open = streams.length;
 
-    for (final s in streams) {
-      subs.add(s.listen(
-        controller.add,
-        onError: controller.addError,
-        onDone: () {
-          open--;
-          if (open == 0) controller.close();
-        },
-      ));
-    }
-
-    try {
-      yield* controller.stream;
-    } finally {
-      for (final s in subs) {
-        await s.cancel();
-      }
-      await controller.close();
-    }
-  }
-}

--- a/lib/core/jellyfin/models/items.dart
+++ b/lib/core/jellyfin/models/items.dart
@@ -77,7 +77,14 @@ class AfTrack {
   final bool isFavorite;
   final bool isDownloaded;
   final DateTime? dateAdded;
-  final List<int>? peaks; // server-provided audio peaks if available
+  /// Per-bar waveform peaks for the visualiser. Currently populated only
+  /// by [DemoLibrary] tracks — Jellyfin does not expose audio peak data
+  /// in its API. For Jellyfin tracks this is always `null` and the Now
+  /// Playing screen falls back to [DemoLibrary.peaksFor] (deterministic
+  /// per track ID) so the visualiser still has a shape to draw. Kept on
+  /// the model so an offline demo experience renders the *real* peak
+  /// pattern instead of going through the fallback path.
+  final List<int>? peaks;
 
   const AfTrack({
     required this.id,

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -281,8 +281,16 @@ final spectralExtractorProvider =
 final spectralProvider =
     FutureProvider.autoDispose.family<Spectral, AfTrack?>((ref, track) async {
   if (track?.imageUrl == null) return Spectral.fallback;
+  // Hand the same Authorization header to PaletteGenerator that the
+  // CachedNetworkImage widgets use — once the token moved out of the
+  // URL query string (review S2), unauthed artwork fetches would 401
+  // and the player UI would flicker back to fallback indigo.
+  final client = ref.watch(jellyfinClientProvider);
+  final headers = client?.authHeaders;
   try {
-    return await ref.watch(spectralExtractorProvider).fromImageUrl(track!.imageUrl!);
+    return await ref
+        .watch(spectralExtractorProvider)
+        .fromImageUrl(track!.imageUrl!, headers: headers);
   } catch (_) {
     return Spectral.fallback;
   }

--- a/lib/widgets/artwork.dart
+++ b/lib/widgets/artwork.dart
@@ -1,12 +1,20 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../design_tokens/tokens.dart';
+import '../state/providers.dart';
 
 /// Network artwork that gracefully degrades to a deterministic indigo
 /// gradient when the URL is null or fails to load. Used everywhere we
 /// need an album/playlist/track cover.
-class Artwork extends StatelessWidget {
+///
+/// The widget reads `jellyfinClientProvider` so it can send the active
+/// `Authorization` header alongside the image fetch. The token used to
+/// ride in the URL as `?api_key=…`; review S2 moved it to a header,
+/// which means Jellyfin servers with auth-required image endpoints
+/// would 401 here without this wiring.
+class Artwork extends ConsumerWidget {
   final String? url;
   final double size;
   final double? height;
@@ -25,7 +33,7 @@ class Artwork extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final w = size;
     final h = height ?? size;
     // `size` / `height` can come from `double.infinity` when Artwork
@@ -66,6 +74,8 @@ class Artwork extends StatelessWidget {
       return physical > 1024 ? 1024 : physical;
     }
 
+    final client = ref.watch(jellyfinClientProvider);
+    final headers = client?.authHeaders;
     return ClipRRect(
       borderRadius: radius,
       child: SizedBox(
@@ -73,6 +83,7 @@ class Artwork extends StatelessWidget {
         height: hFinite,
         child: CachedNetworkImage(
           imageUrl: url!,
+          httpHeaders: headers,
           fit: fit,
           placeholder: (_, __) => placeholder,
           errorWidget: (_, __, ___) => placeholder,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,7 +26,7 @@ packages:
     source: hosted
     version: "2.7.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   google_fonts: ^6.2.1
 
   # Misc
+  async: ^2.11.0
   collection: ^1.18.0
   intl: ^0.19.0
 

--- a/test/pure_functions_test.dart
+++ b/test/pure_functions_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:aetherfin/core/lyrics/lrc_parser.dart';
+import 'package:aetherfin/utils/time_format.dart';
+
+void main() {
+  group('formatTrackDuration', () {
+    test('mm:ss for sub-hour durations', () {
+      expect(formatTrackDuration(Duration.zero), '00:00');
+      expect(formatTrackDuration(const Duration(seconds: 7)), '00:07');
+      expect(formatTrackDuration(const Duration(seconds: 75)), '01:15');
+      expect(formatTrackDuration(const Duration(minutes: 42, seconds: 9)),
+          '42:09');
+    });
+
+    test('hh:mm:ss once hours are present', () {
+      expect(
+          formatTrackDuration(
+              const Duration(hours: 1, minutes: 2, seconds: 3)),
+          '01:02:03');
+      expect(formatTrackDuration(const Duration(hours: 13)), '13:00:00');
+    });
+
+    test('clamps negatives to zero', () {
+      expect(formatTrackDuration(const Duration(seconds: -5)), '00:00');
+    });
+  });
+
+  group('formatHourCount', () {
+    test('returns minutes for sub-hour durations', () {
+      expect(formatHourCount(Duration.zero), '0m');
+      expect(formatHourCount(const Duration(minutes: 7)), '7m');
+      expect(formatHourCount(const Duration(minutes: 59)), '59m');
+    });
+
+    test('rounds to whole hours once >= 1h', () {
+      expect(formatHourCount(const Duration(minutes: 60)), '1h');
+      expect(formatHourCount(const Duration(minutes: 89)), '1h');
+      expect(formatHourCount(const Duration(minutes: 90)), '2h');
+      expect(formatHourCount(const Duration(hours: 103)), '103h');
+    });
+  });
+
+  group('formatCompactCount', () {
+    test('< 1000: passes through', () {
+      expect(formatCompactCount(0), '0');
+      expect(formatCompactCount(42), '42');
+      expect(formatCompactCount(999), '999');
+    });
+
+    test('1000–9999: one decimal K', () {
+      expect(formatCompactCount(1000), '1.0K');
+      expect(formatCompactCount(2247), '2.2K');
+      expect(formatCompactCount(9999), '10.0K');
+    });
+
+    test('10K–999K: whole K', () {
+      expect(formatCompactCount(10_000), '10K');
+      expect(formatCompactCount(12_400), '12K');
+      expect(formatCompactCount(999_499), '999K');
+    });
+
+    test('millions', () {
+      expect(formatCompactCount(1_200_000), '1.2M');
+      expect(formatCompactCount(42_000_000), '42M');
+    });
+  });
+
+  group('parseLrc', () {
+    test('synced lines are sorted by timestamp', () {
+      const src = '''
+[00:12.50] second
+[00:02.10] first
+[00:30.00] third
+''';
+      final lrc = parseLrc(src);
+      expect(lrc.lines.length, 3);
+      expect(lrc.lines[0].text, 'first');
+      expect(lrc.lines[0].start, const Duration(seconds: 2, milliseconds: 100));
+      expect(lrc.lines[1].text, 'second');
+      expect(lrc.lines[2].text, 'third');
+    });
+
+    test('multi-timestamp lines expand into multiple lines', () {
+      const src = '[00:01.00][00:05.00][00:09.00] chorus';
+      final lrc = parseLrc(src);
+      expect(lrc.lines.length, 3);
+      expect(lrc.lines.map((l) => l.text).toSet(), {'chorus'});
+      expect(lrc.lines[0].start, const Duration(seconds: 1));
+      expect(lrc.lines[1].start, const Duration(seconds: 5));
+      expect(lrc.lines[2].start, const Duration(seconds: 9));
+    });
+
+    test('metadata is collected into Lrc.meta', () {
+      const src = '''
+[ti:My Title]
+[ar:My Artist]
+[00:00.00] hello
+''';
+      final lrc = parseLrc(src);
+      expect(lrc.meta['ti'], 'My Title');
+      expect(lrc.meta['ar'], 'My Artist');
+      expect(lrc.lines.length, 1);
+      expect(lrc.lines.first.text, 'hello');
+    });
+
+    test('unparseable lines are skipped, not crashed', () {
+      const src = '''
+random non-LRC line
+[xx:xx.xx] also not valid
+[00:01.00] valid
+''';
+      final lrc = parseLrc(src);
+      expect(lrc.lines.length, 1);
+      expect(lrc.lines.first.text, 'valid');
+    });
+
+    test('activeIndex returns the largest line <= position', () {
+      const src = '''
+[00:00.00] a
+[00:05.00] b
+[00:10.00] c
+''';
+      final lrc = parseLrc(src);
+      expect(lrc.activeIndex(Duration.zero), 0);
+      expect(lrc.activeIndex(const Duration(seconds: 3)), 0);
+      expect(lrc.activeIndex(const Duration(seconds: 5)), 1);
+      expect(lrc.activeIndex(const Duration(seconds: 9)), 1);
+      expect(lrc.activeIndex(const Duration(seconds: 10)), 2);
+      expect(lrc.activeIndex(const Duration(seconds: 999)), 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Second of two PRs implementing the approved code review. **Stacked on top of #11** — merge that one first. Focused on performance (parallel detail fetches, cached artwork bytes), code-quality polish (deps, CLAUDE.md drift, doc clarity), and a couple of correctness fixes that didn't fit PR 1's security theme.

If #11 is merged first, GitHub will auto-retarget this PR to `main` and the diff will collapse to just the PR-2 commits.

### Performance

- **P1** `lib/core/jellyfin/client.dart` — Parallelise the two GETs that back `album()` and `playlist()` via `Future.wait`. The header and tracks fetches are fully independent; running them serially was doubling the wall-clock load of the Album and Playlist detail screens. Now both screens hit time-to-first-byte on the slower of the two requests, not the sum.
- **P2** `lib/core/audio/spectral_extractor.dart` + `lib/state/providers.dart` + `lib/widgets/artwork.dart` — Feed `PaletteGenerator` the same `CachedNetworkImageProvider` that the `Artwork` widget uses, so spectral extraction reads bytes from the disk cache instead of issuing a second network fetch on every track change. Also threads `authHeaders` through both image fetches so PR #11's S2 token-via-header refactor doesn't 401 against Jellyfin servers with auth-required image endpoints.

### Code quality / drift

- **Q1** `CLAUDE.md` §4.2 — Update the motion-spec wording to match the code reality enforced by `design_tokens_test.dart`:
    - Durations are **80 / 160 / 240 / 400 / 600** ms (the doc said 90 / 180 / 240 / 360 / 500).
    - Curves are `easeStandard / easeEmphasized / easeOut / easeIn / linear` (the doc said `easeStandard / easeEntrance / easeExit / easeEmphasis / easeOvershoot`).
    - Long tier is called `long`, not `slow`.
    - Mini-player slide-up curve reference also corrected (`easeOut`, not `easeEntrance`).
- **Q3** `lib/core/jellyfin/discovery.dart` + `pubspec.yaml` — Drop the hand-rolled `StreamGroup` (~25 lines) in favour of `package:async`'s `StreamGroup.merge`. `async` is already in the transitive dep graph (pulled in by `flutter_test` + a handful of Riverpod-adjacent packages); promoting it to a direct dep is a free win.
- **Q4** `test/pure_functions_test.dart` — 17 new test cases covering `formatTrackDuration` (mm:ss / hh:mm:ss / negative clamp), `formatHourCount` (sub-hour / rounding), `formatCompactCount` (passthrough / decimal-K / whole-K / millions), and `parseLrc` (synced / multi-timestamp / metadata / unparseable / `activeIndex`).

### Correctness

- **B9** `client.dart` — `recentlyAddedAlbums()` now flows through the new `_parseRawItemList` helper instead of inline casting, matching the pattern used by every other endpoint. `Items/Latest` returns a top-level JSON array (no `{Items: [...]}` envelope), so the helper centralises that one-off shape without inventing a fake envelope.
- **B10** `client.dart` — Only strip non-ASCII from the `DeviceId` portion of the `MediaBrowser` auth header. Never from `UserId` / `Token`. If a future Jellyfin build ever issues a non-ASCII token (extremely unlikely; current tokens are hex), silently rewriting bytes to `_` would auth-fail in a way that's painful to debug. The non-ASCII strip on `DeviceId` is kept because that field can legitimately contain user-facing device-name bytes.
- **B12** `client.dart` — `lyrics()` returns `null` for **any** 4xx (404 missing, 401/403 no permission, 400 endpoint absent), not just 404. The Lyrics screen renders the tasteful "No lyrics yet" placeholder for `null`, which is the right UX regardless of which 4xx the server returned. 5xx still rethrows so an outage doesn't get silently masked.
- **B13** `lib/core/jellyfin/models/items.dart` — Add an explicit doc-comment on `AfTrack.peaks` clarifying that the field is only populated by `DemoLibrary` tracks (Jellyfin's API doesn't expose audio peak data); the Now Playing screen already falls back to `DemoLibrary.peaksFor(track.id)` for Jellyfin tracks, so this is a documentation fix rather than a code change.

### Tests

- `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings (48 infos, same as baseline).
- `flutter test` — **27/27 pass** (6 design tokens + 17 new pure-function tests + 4 trackStreamUrl + 3 authHeaders, of which the 17 new ones land in this PR).

## Review & Testing Checklist for Human

Lower-risk than PR #11 — most changes are local refactors or new tests. The two items worth a smoke test:

- [ ] **P1 Album / Playlist screens still load correctly.** Tap into an album, then into a playlist. Header + tracks should both populate. The two requests now race, so an error in either one is still propagated through `Future.wait` (no special handling needed) — but worth eyeballing that the screen still falls through to the empty-state placeholder if the album doesn't exist.
- [ ] **P2 Artwork still renders + spectral color still extracts.** Cover-art tiles on Home, Album, and Now Playing should look identical to today; the Now Playing background should still tint from artwork. `adb logcat | grep aetherfin:http` should show ONE artwork fetch per track change now, not two.
- [ ] **CLAUDE.md §4.2 changes are docs-only.** No code or test changes.

### Notes

- The `_VisualiserPainter.shouldRepaint` test from PR #11 (B3) plus the new P2 cached-fetch wiring should together solve the "visualizer thrashes on every frame, including invalidating cached spectral colors" combo issue.
- I deliberately did NOT remove `AfTrack.peaks` (review item B13's alternative resolution) because the demo library still wires it up and the Now Playing screen's `track.peaks ?? DemoLibrary.peaksFor(...)` fallback handles both cases gracefully.
- The `async` package promotion to a direct dep is a tiny surface increase but unblocks future use of `StreamGroup`, `StreamQueue`, `Result`, etc. without re-litigating the dep.