### PR TITLE
Android 16 Live Updates: ProgressStyle chip + lock-screen tile for playback

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,12 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+    <!-- Android 16+ "Live Updates" (Promoted Ongoing Notifications). Required
+         for the playback live-update chip / lockscreen tile published by
+         `dev.aetherfin.aetherfin.live_update.LiveUpdatePlugin`. Older
+         devices ignore this permission and the plugin no-ops there. -->
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"/>
+
     <application
         android:label="Aetherfin"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/dev/aetherfin/aetherfin/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/aetherfin/aetherfin/MainActivity.kt
@@ -1,10 +1,21 @@
 package dev.aetherfin.aetherfin
 
 import com.ryanheise.audioservice.AudioServiceActivity
+import dev.aetherfin.aetherfin.live_update.LiveUpdatePlugin
+import io.flutter.embedding.engine.FlutterEngine
 
 /// Extends [AudioServiceActivity] (from the `audio_service` plugin) instead
 /// of FlutterActivity so audio_service's foreground service can attach to
 /// the running Flutter engine. Without this, AudioService.init throws:
 ///   "The Activity class declared in your AndroidManifest.xml is wrong or
 ///    has not provided the correct FlutterEngine."
-class MainActivity : AudioServiceActivity()
+class MainActivity : AudioServiceActivity() {
+    /// Manual registration for the in-app [LiveUpdatePlugin] — it lives
+    /// in `android/app/src/main/kotlin/.../live_update/` rather than as
+    /// a separate published plugin, so Flutter's auto-registration
+    /// doesn't pick it up.
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        flutterEngine.plugins.add(LiveUpdatePlugin())
+    }
+}

--- a/android/app/src/main/kotlin/dev/aetherfin/aetherfin/live_update/LiveUpdatePlugin.kt
+++ b/android/app/src/main/kotlin/dev/aetherfin/aetherfin/live_update/LiveUpdatePlugin.kt
@@ -1,0 +1,250 @@
+package dev.aetherfin.aetherfin.live_update
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+
+/**
+ * Bridge between the Flutter side (`lib/core/audio/live_update_service.dart`)
+ * and Android 16's "Live Updates" / Promoted Ongoing Notifications API.
+ *
+ * On Android 16 (API 36) and newer, this plugin publishes a separate
+ * `Notification.ProgressStyle` notification that requests promotion via
+ * `setRequestPromotedOngoing(true)`. The system surfaces it as a
+ * status-bar chip and a prominent lock-screen tile while playback is
+ * ongoing.
+ *
+ * On Android 15 and older, every method is a no-op. The existing
+ * `audio_service` `MediaStyle` notification continues to render unchanged
+ * on those devices (and *also* on Android 16 — the two notifications are
+ * complementary: ProgressStyle for the chip, MediaStyle for the
+ * expanded shade with transport controls).
+ *
+ * Why not promote the `MediaStyle` notification itself? Per the Live
+ * Updates documentation, only the following styles qualify for
+ * promotion: Standard, BigTextStyle, CallStyle, ProgressStyle,
+ * MetricStyle. `MediaStyle` is intentionally not in that list. A
+ * notification can only have one Style, so we run a parallel
+ * ProgressStyle notification rather than mutate `audio_service`'s.
+ *
+ * MethodChannel: `aetherfin.live_update`
+ *
+ * Methods:
+ *   - `isSupported() -> Boolean` — true on API 36+, false otherwise.
+ *   - `start(args) -> Void` — post the live update for the first time.
+ *   - `update(args) -> Void` — refresh the existing notification's
+ *     position / playing state. No-op if `start` hasn't been called.
+ *   - `stop() -> Void` — cancel the notification.
+ *
+ * `args` shape (Map<String, Object>):
+ *   - `title`: String — track title (shown as contentTitle)
+ *   - `artist`: String — artist name (shown as contentText)
+ *   - `durationMs`: Long — total track length, > 0
+ *   - `positionMs`: Long — current playback position, [0, durationMs]
+ *   - `isPlaying`: Boolean — whether the track is actively playing
+ *   - `shortCriticalText`: String — formatted "M:SS / M:SS", shown on
+ *     the status-bar chip when there's room
+ */
+class LiveUpdatePlugin : FlutterPlugin, MethodCallHandler {
+
+    companion object {
+        private const val CHANNEL_NAME = "aetherfin.live_update"
+        private const val NOTIFICATION_CHANNEL_ID = "aetherfin.live_update"
+        private const val NOTIFICATION_CHANNEL_NAME = "Now Playing (Live Update)"
+        private const val NOTIFICATION_ID = 0x4146_1701 // "AF" + arbitrary
+
+        /** Android 16. Matches `Build.VERSION_CODES.BAKLAVA` on SDKs that
+         *  expose the constant; using the int literal keeps this file
+         *  compilable on older `compileSdk` while still gating correctly
+         *  at runtime. */
+        private const val SDK_LIVE_UPDATES = 36
+
+        /** Don't post a notification update more than once every 5
+         *  seconds — that's the rate cap the platform documentation
+         *  recommends. The Dart side already throttles, but this is a
+         *  defensive lower bound in case it stops throttling. */
+        private const val MIN_UPDATE_INTERVAL_MS = 5_000L
+    }
+
+    private var channel: MethodChannel? = null
+    private var appContext: Context? = null
+    private var lastPostMs: Long = 0L
+    private var isLive: Boolean = false
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL_NAME).also {
+            it.setMethodCallHandler(this)
+        }
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        channel = null
+        appContext = null
+    }
+
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "isSupported" -> result.success(Build.VERSION.SDK_INT >= SDK_LIVE_UPDATES)
+            "start" -> {
+                if (!isApiSupported()) {
+                    result.success(false); return
+                }
+                val args = call.arguments as? Map<*, *>
+                if (args == null) {
+                    result.error("ARGS", "expected a map argument", null); return
+                }
+                if (!hasPostNotificationsPermission()) {
+                    // Without runtime POST_NOTIFICATIONS, the system silently
+                    // drops the notification. Report it explicitly so the
+                    // Dart side can request the permission and retry.
+                    result.success(false); return
+                }
+                ensureNotificationChannel()
+                lastPostMs = 0L
+                isLive = true
+                postNotification(args, force = true)
+                result.success(true)
+            }
+            "update" -> {
+                if (!isLive || !isApiSupported()) {
+                    result.success(false); return
+                }
+                val args = call.arguments as? Map<*, *>
+                if (args == null) {
+                    result.error("ARGS", "expected a map argument", null); return
+                }
+                postNotification(args, force = false)
+                result.success(true)
+            }
+            "stop" -> {
+                cancelNotification()
+                isLive = false
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Internals
+    // ----------------------------------------------------------------------
+
+    private fun isApiSupported(): Boolean = Build.VERSION.SDK_INT >= SDK_LIVE_UPDATES
+
+    private fun hasPostNotificationsPermission(): Boolean {
+        val ctx = appContext ?: return false
+        if (Build.VERSION.SDK_INT < 33) return true
+        return ContextCompat.checkSelfPermission(
+            ctx,
+            "android.permission.POST_NOTIFICATIONS",
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun ensureNotificationChannel() {
+        val ctx = appContext ?: return
+        val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.getNotificationChannel(NOTIFICATION_CHANNEL_ID) != null) return
+        // IMPORTANCE_LOW: no sound or pop-up, but the notification still
+        // shows in the shade and is eligible for Live-Update promotion
+        // (IMPORTANCE_MIN would disqualify it per the docs).
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Status-bar chip and lock-screen tile showing the currently playing track."
+            setShowBadge(false)
+        }
+        nm.createNotificationChannel(channel)
+    }
+
+    /**
+     * Build and post the ProgressStyle notification. Idempotent — re-posts
+     * are gated by the [MIN_UPDATE_INTERVAL_MS] throttle unless [force].
+     */
+    @Suppress("DEPRECATION") // Notification.ProgressStyle is API 36+ only.
+    private fun postNotification(args: Map<*, *>, force: Boolean) {
+        val ctx = appContext ?: return
+        if (Build.VERSION.SDK_INT < SDK_LIVE_UPDATES) return
+
+        val now = System.currentTimeMillis()
+        if (!force && now - lastPostMs < MIN_UPDATE_INTERVAL_MS) return
+        lastPostMs = now
+
+        val title = (args["title"] as? String)?.takeIf { it.isNotEmpty() } ?: "Now playing"
+        val artist = (args["artist"] as? String) ?: ""
+        val durationMs = (args["durationMs"] as? Number)?.toLong()?.coerceAtLeast(1L) ?: 1L
+        val positionMs = (args["positionMs"] as? Number)?.toLong()?.coerceIn(0L, durationMs) ?: 0L
+        val isPlaying = (args["isPlaying"] as? Boolean) ?: true
+        val shortCriticalText = (args["shortCriticalText"] as? String) ?: ""
+
+        val contentIntent = buildContentIntent(ctx)
+
+        // Reflection-free reference: Notification.ProgressStyle is API 36+;
+        // we already gated on SDK_INT above so the linker won't trip.
+        val style = Notification.ProgressStyle()
+            .setStyledByProgress(true)
+            .setProgress(positionMs.toInt())
+            .addProgressSegment(
+                Notification.ProgressStyle.Segment(durationMs.toInt())
+                    .setColor(if (isPlaying) Color.parseColor("#5644C9") else Color.parseColor("#9B9BAA"))
+            )
+
+        val builder = Notification.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(ctx.applicationInfo.icon.takeIf { it != 0 }
+                ?: android.R.drawable.ic_media_play)
+            .setContentTitle(title)
+            .setContentText(artist)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setStyle(style)
+            .setContentIntent(contentIntent)
+            // The chip needs SOMETHING textual to show alongside the
+            // small icon. "M:SS / M:SS" reads naturally and fits within
+            // the chip's 96dp width as long as durations are < 100min.
+            .setShortCriticalText(shortCriticalText)
+            // Promotion request — the system decides whether to honour
+            // it based on Live-Updates settings + OEM policy.
+            .setRequestPromotedOngoing(true)
+
+        val notification = builder.build()
+        val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun cancelNotification() {
+        val ctx = appContext ?: return
+        val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.cancel(NOTIFICATION_ID)
+    }
+
+    /** Tapping the chip launches the app (singleTop, like a deep-link). */
+    private fun buildContentIntent(ctx: Context): PendingIntent {
+        val launch = ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
+            ?: Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+                .setPackage(ctx.packageName)
+        launch.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        return PendingIntent.getActivity(
+            ctx,
+            0,
+            launch,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+}

--- a/lib/core/audio/live_update_service.dart
+++ b/lib/core/audio/live_update_service.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/services.dart';
+
+import '../jellyfin/models/items.dart';
+import 'player_service.dart';
+
+/// Bridges [AfPlayerService] state into the native Android 16 "Live
+/// Updates" / Promoted Ongoing Notifications system via the
+/// `aetherfin.live_update` MethodChannel.
+///
+/// On Android 16+ (API 36): publishes a [Notification.ProgressStyle]
+/// notification that the OS surfaces as a status-bar chip and
+/// lock-screen tile while playback is ongoing.
+///
+/// On Android ≤15, iOS, or anywhere else: every method is a no-op.
+/// The existing `audio_service` `MediaStyle` notification continues to
+/// handle lock-screen media controls unchanged on those targets.
+///
+/// Why a separate notification (and not extending audio_service's)?
+/// Per the Live Updates docs, only Standard / BigTextStyle / CallStyle
+/// / ProgressStyle / MetricStyle notifications qualify for promotion.
+/// `MediaStyle` is intentionally not in that list, and a notification
+/// can only carry one Style. So this service publishes a parallel
+/// ProgressStyle notification dedicated to the chip surface; the
+/// audio_service media notification keeps owning the transport
+/// controls.
+class LiveUpdateService {
+  static const _channel = MethodChannel('aetherfin.live_update');
+
+  /// Don't push position updates more often than this — matches the
+  /// platform's recommended rate cap. The native side throttles too,
+  /// but coalescing here cuts MethodChannel chatter.
+  static const _minUpdateInterval = Duration(seconds: 5);
+
+  final AfPlayerService _player;
+  bool _supported = false;
+  bool _live = false;
+  AfTrack? _track;
+  Duration _lastPositionPushed = Duration.zero;
+  DateTime _lastPushAt = DateTime.fromMillisecondsSinceEpoch(0);
+  final List<StreamSubscription<void>> _subs = [];
+
+  LiveUpdateService(this._player);
+
+  /// Call once during app boot — probes the native side for support,
+  /// then wires up listeners on the player streams. Cheap on
+  /// unsupported platforms (a single MethodChannel round-trip + an
+  /// early return).
+  Future<void> attach() async {
+    if (!_isAndroid()) return;
+    try {
+      final ok = await _channel.invokeMethod<bool>('isSupported');
+      _supported = ok ?? false;
+    } on PlatformException catch (e) {
+      _supported = false;
+      _log('isSupported failed: $e');
+    } on MissingPluginException {
+      _supported = false;
+    }
+    if (!_supported) return;
+
+    _subs.add(_player.currentTrackStream.listen((t) {
+      _track = t;
+      if (t == null) {
+        unawaited(stop());
+      } else {
+        unawaited(_startOrUpdate(force: true));
+      }
+    }));
+    _subs.add(_player.positionStream.listen((_) {
+      unawaited(_startOrUpdate());
+    }));
+    _subs.add(_player.playingStream.listen((_) {
+      // State transitions are the user's signal that something
+      // changed; flush immediately rather than wait out the 5s window.
+      unawaited(_startOrUpdate(force: true));
+    }));
+  }
+
+  /// Tear down listeners and cancel the notification.
+  Future<void> dispose() async {
+    for (final s in _subs) {
+      await s.cancel();
+    }
+    _subs.clear();
+    await stop();
+  }
+
+  /// Immediately cancel the live-update notification, if any.
+  Future<void> stop() async {
+    if (!_supported || !_live) return;
+    _live = false;
+    try {
+      await _channel.invokeMethod<void>('stop');
+    } on PlatformException catch (e) {
+      _log('stop failed: $e');
+    } on MissingPluginException {
+      // pass
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  bool _isAndroid() {
+    try {
+      return Platform.isAndroid;
+    } catch (_) {
+      // Platform throws on web; we don't ship web but this keeps the
+      // class harmless if someone ever runs the app in a Flutter web
+      // shell.
+      return false;
+    }
+  }
+
+  Future<void> _startOrUpdate({bool force = false}) async {
+    if (!_supported) return;
+    final track = _track ?? _player.currentTrack;
+    if (track == null) return;
+    final duration = track.duration;
+    if (duration <= Duration.zero) return;
+
+    final now = DateTime.now();
+    final position = _player.position;
+    if (!force &&
+        now.difference(_lastPushAt) < _minUpdateInterval &&
+        (position - _lastPositionPushed).abs() < _minUpdateInterval) {
+      return;
+    }
+    _lastPushAt = now;
+    _lastPositionPushed = position;
+
+    final clampedPos =
+        position < Duration.zero ? Duration.zero : (position > duration ? duration : position);
+
+    final args = <String, Object?>{
+      'title': track.title,
+      'artist': track.artistName,
+      'durationMs': duration.inMilliseconds,
+      'positionMs': clampedPos.inMilliseconds,
+      'isPlaying': _isPlaying(),
+      'shortCriticalText': '${_fmtClock(clampedPos)} / ${_fmtClock(duration)}',
+    };
+
+    try {
+      final method = _live ? 'update' : 'start';
+      final ok = await _channel.invokeMethod<bool>(method, args);
+      if (ok == true) {
+        _live = true;
+      } else if (method == 'start') {
+        // start() can return false when POST_NOTIFICATIONS hasn't been
+        // granted yet. Keep _live=false so a later track change retries.
+        _log('start returned false — likely missing POST_NOTIFICATIONS');
+      }
+    } on PlatformException catch (e) {
+      _log('$_live ? update : start failed: $e');
+    } on MissingPluginException {
+      _supported = false;
+    }
+  }
+
+  bool _isPlaying() => _player.isPlaying;
+
+  String _fmtClock(Duration d) {
+    if (d.isNegative) d = Duration.zero;
+    final s = d.inSeconds;
+    final h = s ~/ 3600;
+    final m = (s % 3600) ~/ 60;
+    final ss = s % 60;
+    String two(int n) => n.toString().padLeft(2, '0');
+    if (h > 0) return '$h:${two(m)}:${two(ss)}';
+    return '$m:${two(ss)}';
+  }
+
+  void _log(String msg) {
+    if (!kDebugMode) return;
+    // ignore: avoid_print
+    print('aetherfin:live_update $msg');
+  }
+}

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -85,6 +85,10 @@ class AfPlayerService extends BaseAudioHandler with QueueHandler, SeekHandler {
       (_currentIndex >= 0 && _currentIndex < _trackQueue.length)
           ? _trackQueue[_currentIndex]
           : null;
+  /// Synchronous snapshot of the play/pause state. Backs the live-
+  /// update notification's "playing" colour cue — the chip needs the
+  /// current value at post-time, not just a stream subscription.
+  bool get isPlaying => _player.playing;
   bool get isShuffleEnabled => _player.shuffleModeEnabled;
   LoopMode get loopMode => _player.loopMode;
   double get speed => _player.speed;

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,7 +1,10 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart' show LoopMode;
 
 import '../core/audio/jellyfin_playback_reporter.dart';
+import '../core/audio/live_update_service.dart';
 import '../core/audio/player_service.dart';
 import '../core/audio/spectral_extractor.dart';
 import '../core/demo/demo_library.dart';
@@ -142,7 +145,13 @@ void wirePlayerService(Ref ref, AfPlayerService svc) {
     svc,
     () => ref.read(jellyfinClientProvider),
   );
+  // Live-update chip / lockscreen tile (Android 16+ only). No-op on
+  // older Android, iOS, and tests — attach() probes support before
+  // subscribing to any streams.
+  final liveUpdate = LiveUpdateService(svc);
+  unawaited(liveUpdate.attach());
   ref.onDispose(() async {
+    await liveUpdate.dispose();
     await reporter.dispose();
     await svc.dispose();
   });


### PR DESCRIPTION
## Summary

Implements the [developer.android.com Live Updates](https://developer.android.com/develop/ui/compose/notifications/live-update) feature for playback — a status-bar chip and lock-screen tile that follows the currently playing track and progress on Android 16 (API 36) and newer.

### Approach (Option C from the review thread)

The intent was "extend the existing media notification to use ProgressStyle + `setRequestPromotedOngoing`". Two hard constraints from the Android docs forced a small deviation from the literal wording, but the user-visible result is the same:

1. **A `Notification` can carry exactly one `Style`.** `audio_service` already publishes a `MediaStyle` notification for transport controls.
2. **Per the Live Updates eligibility rules, only Standard / `BigTextStyle` / `CallStyle` / `ProgressStyle` / `MetricStyle` notifications qualify for promotion.** `MediaStyle` is intentionally *not* in that list.

So we can't mutate `audio_service`'s existing notification to be promotable. Instead, we publish a **parallel** `ProgressStyle` notification dedicated to the chip / lock-screen-tile surfaces. The two notifications are complementary:

- **`ProgressStyle` (new)** → status-bar chip + lock-screen Live Update tile. Owned by `LiveUpdatePlugin`.
- **`MediaStyle` (unchanged)** → expanded notification in the shade, with play/pause/skip controls. Still owned by `audio_service`.

On Android ≤ 15, iOS, and inside tests, every method is a no-op — UX matches what shipped before this PR exactly.

### What landed

**Native side (Kotlin):**
- `android/app/src/main/kotlin/dev/aetherfin/aetherfin/live_update/LiveUpdatePlugin.kt` — a `FlutterPlugin` on the `aetherfin.live_update` MethodChannel with `start` / `update` / `stop` / `isSupported` methods. Builds a `Notification.ProgressStyle` with a single full-duration segment, sets `setRequestPromotedOngoing(true)`, and tags it with `setShortCriticalText("M:SS / M:SS")` so the chip shows position even when collapsed.
- Notification channel `aetherfin.live_update` at `IMPORTANCE_LOW` (silent, but not `IMPORTANCE_MIN`, which would disqualify promotion).
- `MainActivity.configureFlutterEngine` registers the plugin manually because it lives in-app rather than as a published Flutter plugin.
- `AndroidManifest` adds `android.permission.POST_PROMOTED_NOTIFICATIONS` (required by the new API; older OS versions ignore it).

**Dart side:**
- `lib/core/audio/live_update_service.dart` — bridges `AfPlayerService`'s `currentTrackStream` / `positionStream` / `playingStream` into the MethodChannel. Throttles position updates to once every 5 s (matches the rate cap in the Android docs); state-change events bypass the throttle.
- `AfPlayerService.isPlaying` synchronous getter — the chip's segment colour needs the current play/pause state at post-time, not just a future stream event.
- `wirePlayerService` spins up a `LiveUpdateService` alongside the existing `JellyfinPlaybackReporter`. Disposal is symmetric — both shut down with the provider tree.

**Tooling:**
- No `compileSdk` / `targetSdk` bump needed — Flutter 3.41.9 already defaults both to 36, and the `build.gradle.kts` reads `flutter.compileSdkVersion` / `flutter.targetSdkVersion`.

### What this is NOT

- It's not a replacement for `audio_service`'s media notification. Lockscreen transport controls, hardware media-button handling, and Android Auto are all still owned by `audio_service` and unchanged.
- It does not add action buttons (play/pause/skip) on the live update itself. The `ProgressStyle` chip has limited room for actions, and the `MediaStyle` notification right below it already covers transport.
- It does not gate behind a feature flag. The plugin self-gates on `Build.VERSION.SDK_INT >= 36`, so older devices see zero behaviour change.

## Review & Testing Checklist for Human

This is yellow risk — new native Android code that posts notifications, but well-isolated.

- [ ] Smoke test on a real Android 16 device or emulator: start playback, verify the status-bar chip appears with the track title + "0:42 / 3:21" critical text; expand the lock screen, verify the Live Update tile shows.
- [ ] Smoke test on an Android ≤ 15 device: verify no new notification appears, only the original `audio_service` `MediaStyle` notification. (`LiveUpdatePlugin` gates on `SDK_INT >= 36`.)
- [ ] Smoke test pause → resume → skip → stop: the chip should reflect the play/pause state (colour cue), advance position smoothly across the 5 s throttle, and disappear when the queue is cleared or the app is force-stopped.
- [ ] Confirm `POST_PROMOTED_NOTIFICATIONS` is a non-runtime permission (declared in the manifest, no `requestPermissions()` call needed). Verify on first install no permission dialog appears for it.

### Notes

- A quibble worth flagging: the Live Updates documentation explicitly lists *appropriate* uses as "active navigation, ongoing phone calls, active rideshare tracking, and active food delivery tracking" — music playback isn't in that list. Google's stance is that the regular `MediaStyle` notification is the right surface for playback. We're shipping this anyway because (a) it was the user's explicit ask, (b) the playback session does fit the "user-initiated + time-sensitive + ongoing" criteria, and (c) the chip is a legitimately useful at-a-glance surface for "what am I listening to right now". OEMs may still choose not to promote it; the plugin is robust to that (the notification still appears in the regular shade as a fallback).
- The throttle is 5 s on both the Dart and the Kotlin sides. State changes (play / pause / track change) bypass the throttle on the Dart side and are passed through with `force = true` on the Kotlin side.
