### PR TITLE
ci(pr-checks): drop debug APK build + artifact upload

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,10 @@
 name: PR checks
 
-# Runs analyze + test + a debug APK build on every pull request and on
-# pushes to `main`. The release-signed `build-apk.yml` workflow stays
-# manual-dispatch only — this workflow exists purely to catch regressions
-# (Kotlin compile errors, lint warnings, broken tests) before merge.
+# Runs analyze + test on every pull request and on pushes to `main`. The
+# release-signed `build-apk.yml` workflow stays manual-dispatch only — this
+# workflow exists purely to catch Dart-level regressions (lint, tests)
+# before merge. APK builds are intentionally NOT run here; trigger
+# `build-apk.yml` manually when you need a build artifact.
 on:
   pull_request:
     branches: [main, master]
@@ -20,21 +21,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze-test-build:
-    name: Analyze, test, debug APK
+  analyze-test:
+    name: Analyze + test
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: gradle
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -56,7 +50,6 @@ jobs:
       - name: Show toolchain versions
         run: |
           flutter --version
-          java -version
           dart --version
 
       - name: Install dependencies
@@ -67,14 +60,3 @@ jobs:
 
       - name: Test
         run: flutter test
-
-      - name: Build debug APK
-        run: flutter build apk --debug
-
-      - name: Upload debug APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-debug-apk-${{ github.sha }}
-          path: build/app/outputs/flutter-apk/app-debug.apk
-          if-no-files-found: error
-          retention-days: 7


### PR DESCRIPTION
## Summary

Follow-up to PR #14. Drops the `Build debug APK` and `Upload debug APK artifact` steps from `.github/workflows/pr-checks.yml` so PR checks only run `flutter analyze --no-fatal-infos` + `flutter test`.

**Why:** APK builds are slow and the analyze/test pair is the fast signal that catches the regressions this workflow was meant to catch (Dart lint, broken tests). When an actual APK is needed, the existing `build-apk.yml` workflow (workflow_dispatch + release signing + Telegram delivery) is the right tool — running it on every PR was overkill.

**Side effects:**
- Workflow timeout reduced from 25 → 15 min.
- JDK 17 setup step removed (no longer needed without `flutter build apk`).
- No more `app-debug-apk-<sha>` artifact attached to PRs.

**Trade-off (called out so it's not surprising later):** Kotlin compile errors like the `setRequestPromotedOngoing` API-level issue from PR #14 will no longer be caught by PR checks — they'll only surface on the next manual `build-apk.yml` run. The user accepted this trade-off.

## Review & Testing Checklist for Human

Risk: green — single-file CI config change.

- [ ] Confirm the new `pr-checks` workflow run on this PR shows only the `Analyze + test` job (no `Build debug APK` step) and passes.

### Notes

No Dart/Kotlin code touched.
