### PR TITLE
docs: update all docs for multi-backend (Jellyfin + Navidrome) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,33 @@ and is updated as we learn more.
 ## 1. What Aetherfin is
 
 A native-feeling Android music player backed by a self-hosted **Jellyfin**
-server. The only first-class platform is Android. iOS may follow but is not
-considered when making trade-offs.
+or **Navidrome** server. The only first-class platform is Android. iOS may
+follow but is not considered when making trade-offs.
 
 > **North star:** Spotify's polish, Apple Music's typography, Soulseek's
 > respect for the listener. Aetherfin must read as a *premium music* app,
-> not "a Jellyfin client."
+> not "a Jellyfin/Navidrome client."
 
 ### 1.1 Mental model — what runs where
 
-Treat Jellyfin as a **file source + library state store**, nothing else.
-**Aetherfin is the player.**
+Treat the server (Jellyfin or Navidrome) as a **file source + library state
+store**, nothing else. **Aetherfin is the player.**
 
-**Jellyfin (server) is responsible for:**
+The app supports two server backends via the `MusicBackend` abstraction
+(`lib/core/backend/music_backend.dart`). `ServerType` (jellyfin | subsonic)
+is persisted in auth storage and determines which client is instantiated.
+
+**Server (Jellyfin or Navidrome) is responsible for:**
 - Storing audio files and serving the original bytes byte-for-byte.
 - Catalog metadata: titles, artists, albums, genres, durations, year, artwork.
-- Search (`/Users/{id}/Items?searchTerm=…` — never `/Search/Hints`).
-- Auth (user accounts + access tokens).
+- Search (Jellyfin: `/Users/{id}/Items?searchTerm=…` — never `/Search/Hints`;
+  Navidrome: `search3.view`).
+- Auth (Jellyfin: user accounts + access tokens; Navidrome: Subsonic token
+  auth — `md5(password + salt)`).
 - Per-user state: favorites, play counts, last-played-at, playlists.
 - LRC lyric files (stored only; the app parses them).
-- "Now Playing" telemetry display — `POST /Sessions/Playing*` exists
-  purely so the Jellyfin Dashboard widget shows who's listening to what.
+- "Now Playing" telemetry display — Jellyfin: `POST /Sessions/Playing*`;
+  Navidrome: `scrobble.view`.
 
 **Aetherfin (app) is responsible for everything else, on-device:**
 - All audio **decoding** (libmpv via `mpv_audio_kit`).
@@ -43,22 +49,28 @@ Treat Jellyfin as a **file source + library state store**, nothing else.
 - Cover-art file cache (`cached_network_image`).
 - Local settings: audio-quality preference, sleep timer, EQ/DSP, ReplayGain.
 
-**Strict consequence:** stream URLs MUST use
+**Strict consequence (Jellyfin):** stream URLs MUST use
 `/Audio/{id}/stream?Static=true` — the direct-stream endpoint. The
 universal endpoint (`/Audio/{id}/universal`) triggers server-side
 transcoding to HLS, which (1) wastes the server's CPU, (2) gives a
 codec that may not decode cleanly, and (3) was the cause of the
 "track plays but position never advances" bug.
 
-**Strict consequence #2:** stream URLs embed `api_key=<token>` as a query
-parameter because FFmpeg/libmpv rejects the `Authorization: MediaBrowser …`
-header (it contains commas, which FFmpeg treats as header-list separators).
-This is the standard approach for mpv-based Jellyfin clients.
+**Strict consequence (Navidrome):** stream URLs use
+`/rest/stream.view?id={id}&u=…&t=…&s=…&v=1.16.1&c=Aetherfin&f=json`.
+Auth is embedded as query parameters (username, token, salt) because
+libmpv/FFmpeg cannot use Subsonic header auth.
+
+**Strict consequence #2:** stream URLs embed auth as query parameters.
+Jellyfin: `api_key=<token>`. Navidrome: `u`, `t` (md5 hash), `s` (salt).
+FFmpeg/libmpv rejects the `Authorization: MediaBrowser …` header
+(commas treated as header-list separators).
 
 **Strict consequence #3:** favorites, play counts, and playlist contents
-are server-owned even though the heart icon flips locally first. The
-client does optimistic UI then `POST/DELETE /Users/{id}/FavoriteItems/
-{itemId}`. On HTTP error, revert. Never store favorite state only on-device.
+are server-owned even though the heart icon flips locally first.
+Jellyfin: `POST/DELETE /Users/{id}/FavoriteItems/{itemId}`.
+Navidrome: `star.view` / `unstar.view`.
+On HTTP error, revert. Never store favorite state only on-device.
 
 ## 2. Tech stack (exact versions)
 
@@ -67,11 +79,12 @@ client does optimistic UI then `POST/DELETE /Users/{id}/FavoriteItems/
 | Framework | Flutter **3.41.9 stable**, Dart **3.11.5** | `flutter --version` must match. CI pins this. |
 | State | `flutter_riverpod` ^2.6 | `FutureProvider.autoDispose`, `StateNotifierProvider`. No `ChangeNotifier` for Riverpod providers. |
 | Routing | `go_router` ^14.7 | Shell route with bottom nav. See `lib/app/router.dart`. |
-| HTTP | `dio` ^5.7 + `dio_cache_interceptor` ^3.5 | One Dio per `JellyfinClient`. Auth header baked into `BaseOptions.headers`. |
+| HTTP | `dio` ^5.7 + `dio_cache_interceptor` ^3.5 | One Dio per client. Jellyfin: auth header in `BaseOptions.headers`. Subsonic: auth as query params. |
+| Crypto | `crypto` ^3.0.6 | Subsonic token auth: `md5(password + salt)`. |
 | Audio | `mpv_audio_kit` ^0.1.3 | libmpv-backed player. Replaces `just_audio` + `audio_session`. |
 | Lock-screen | `audio_service` ^0.18 | `AfPlayerService extends BaseAudioHandler`. |
 | Storage | `flutter_secure_storage` ^9.2 (creds + deviceId), `shared_preferences` ^2.3 (settings) | Never store creds in shared_preferences. |
-| Discovery | `multicast_dns` ^0.3.2 | mDNS scan for `_jellyfin._tcp`. |
+| Discovery | `multicast_dns` ^0.3.2 | mDNS scan for `_jellyfin._tcp`. Navidrome: probed via Subsonic `ping.view`. |
 | Imagery | `cached_network_image` ^3.4, `flutter_svg` ^2.0, `palette_generator_master` ^1.1 | All cover art through `cached_network_image`. |
 | Fonts | `google_fonts` ^6.2, `cupertino_icons` ^1.0.8 | Inter Variable + JetBrains Mono. cupertino_icons satisfies transitive font validator. |
 | UUID | `uuid` ^4.5 | Fallback device ID generation (cryptographically random). |
@@ -195,19 +208,33 @@ lib/
 │  │  │                               Syncs _trackQueue via _player.stream.playlist.first after command.
 │  │  │                               Track-ID guard in playlist listener prevents displayed song change.
 │  │  │                               _originalQueue stores unshuffled order.
-│  │  ├─ play_actions.dart          ← Cross-cutting play entry points
+│  │  ├─ play_actions.dart          ← Cross-cutting play entry points (uses MusicBackend)
 │  │  │                               PlayActions.playQueue shuffles before loading when shuffle is ON.
-│  │  ├─ jellyfin_playback_reporter.dart ← POST /Sessions/Playing* lifecycle
+│  │  ├─ jellyfin_playback_reporter.dart ← Playback reporting lifecycle (uses MusicBackend)
+│  │  │                               Jellyfin: POST /Sessions/Playing*
+│  │  │                               Navidrome: scrobble.view
 │  │  │                               Serialized progress loop (not Timer.periodic), 5s timeouts.
 │  │  ├─ live_update_service.dart   ← Android 16+ Live Update chip (in-flight guard)
 │  │  └─ spectral_extractor.dart    ← palette_generator → Spectral triple (LRU cache)
+│  ├─ backend/
+│  │  └─ music_backend.dart ← Abstract MusicBackend interface. Both JellyfinClient and
+│  │                          SubsonicClient implement this. Defines all server operations:
+│  │                          library browsing, search, favorites, playlists, streaming,
+│  │                          playback reporting, lyrics. ServerType enum exported here.
 │  ├─ battery_opt.dart      ← Dart bridge to BatteryOptPlugin (aetherfin.battery_opt channel)
 │  ├─ demo/                 ← DemoLibrary — bundled albums/artists for onboarding preview
 │  ├─ jellyfin/
-│  │  ├─ client.dart        ← THE ONLY file that speaks HTTP to Jellyfin
-│  │  ├─ auth_storage.dart  ← secure_storage wrappers (token, userId, deviceId)
+│  │  ├─ client.dart        ← THE ONLY file that speaks HTTP to Jellyfin (implements MusicBackend)
+│  │  ├─ auth_storage.dart  ← secure_storage wrappers (token, userId, deviceId, serverType)
 │  │  ├─ discovery.dart     ← mDNS scan + public-info probe
 │  │  └─ models/            ← Plain Dart classes — NO json_serializable codegen
+│  │                          server.dart includes ServerType enum + JellyfinAuth (used by both backends)
+│  ├─ subsonic/
+│  │  └─ client.dart        ← THE ONLY file that speaks HTTP to Navidrome (implements MusicBackend)
+│  │                          Subsonic/OpenSubsonic REST API. Token auth: md5(password + salt).
+│  │                          Random salt per request. All endpoints: albums, artists, tracks,
+│  │                          playlists (CRUD), search, favorites, genres, lyrics, similar songs,
+│  │                          scrobbling. Stream/cover art URLs embed auth as query params.
 │  └─ lyrics/               ← LRC parser (sync + unsynced)
 ├─ features/                ← One folder per top-level screen
 │  ├─ home/        library/  album/      artist/     genre/
@@ -222,6 +249,8 @@ lib/
 │  │                            Go to album, Go to artist) and album tiles (Play album, Go to artist).
 ├─ state/
 │  └─ providers.dart        ← All Riverpod providers in one file (intentional)
+│                             musicBackendProvider creates JellyfinClient or SubsonicClient
+│                             based on auth.serverType. jellyfinClientProvider kept as alias.
 ├─ widgets/                 ← Shared visual atoms
 │  ├─ mini_player.dart      ← 56 dp floating mini-player
 │  ├─ audio_visual_scrubber.dart ← Combined FFT visualizer + progress scrubber.
@@ -352,6 +381,40 @@ Storage IO has a 5s timeout; `AudioService.init` has a 10s timeout.
 `authProvider` changes. The `redirect` callback sends signed-in users
 to `/home` and anonymous users to `/`. Every onboarding route must
 start with `/onboarding/`.
+
+### 5.4 Subsonic (Navidrome) auth
+
+Navidrome uses the Subsonic API authentication scheme. Every request
+carries these query parameters (not headers):
+
+| Param | Value |
+|---|---|
+| `u` | Username |
+| `t` | `md5(password + salt)` — computed fresh per request |
+| `s` | Random salt (unique per request to prevent replay) |
+| `v` | `1.16.1` (Subsonic API version) |
+| `c` | `Aetherfin` (client identifier) |
+| `f` | `json` (response format) |
+
+Rules:
+- **Password is stored in `JellyfinAuth.accessToken`** (encrypted in
+  `flutter_secure_storage`). Needed to compute the per-request token.
+- **Salt is random per request** — never reuse salts.
+- **No Authorization header** — Subsonic auth is purely query-param-based.
+- **Stream and cover art URLs embed auth** — same params as above appended
+  to `/rest/stream.view?id=…` and `/rest/getCoverArt.view?id=…`.
+- The canonical implementation lives in `SubsonicClient._authParams()`
+  at `lib/core/subsonic/client.dart`. **Do not duplicate this logic.**
+
+### 5.5 Server detection during onboarding
+
+The server discovery screen (`server_discovery_screen.dart`) probes
+servers in order:
+1. Try Jellyfin `publicInfo()` — if it responds, server is Jellyfin.
+2. If that fails, try Subsonic `ping.view` — Navidrome responds with a
+   Subsonic API envelope even on bad credentials.
+3. The detected `ServerType` is passed to the sign-in screen via the
+   router's `extra` parameter.
 
 ## 6. Navigation rules
 
@@ -504,11 +567,22 @@ PII (usernames, server URLs) must be redacted in release builds.
 
 ## 13. Data layer conventions
 
-- `JellyfinClient` is the **only** file that speaks HTTP.
-- All endpoints assert `userId` via `_assertUser()`.
+- Two HTTP clients, each the **only** file that speaks to its server:
+  - `JellyfinClient` (`lib/core/jellyfin/client.dart`) — Jellyfin REST API.
+  - `SubsonicClient` (`lib/core/subsonic/client.dart`) — Subsonic/OpenSubsonic API (Navidrome).
+- Both implement `MusicBackend` (`lib/core/backend/music_backend.dart`).
+  All providers and UI code use `musicBackendProvider` which returns the
+  correct client based on `auth.serverType`.
+- `JellyfinClient` endpoints assert `userId` via `_assertUser()`.
+  `SubsonicClient` endpoints embed auth via `_authParams()`.
 - No `json_serializable`. Models are hand-written in `lib/core/jellyfin/models/`.
-- Image URLs embed the `tag` query param for HTTP cacheability.
+  Both clients parse responses into the same `AfTrack`, `AfAlbum`, `AfArtist`,
+  `AfPlaylist` types.
+- Image URLs: Jellyfin embeds the `tag` query param for HTTP cacheability.
+  Navidrome uses `/rest/getCoverArt.view?id=…` with auth params.
 - Search queries are normalized (trim + lowercase) before hitting the provider. Minimum 2 characters.
+- **Subsonic API gaps:** `resumeItems()` returns empty list (no Subsonic
+  equivalent). `movePlaylistItem()` is a no-op (logs warning).
 
 ## 14. PR & CI rules
 
@@ -545,6 +619,11 @@ PII (usernames, server URLs) must be redacted in release builds.
 24. **"Implement shuffle by rebuilding the queue in Dart."** No. Use mpv's native `setShuffle(true/false)` which calls `playlist-shuffle`/`playlist-unshuffle` without interrupting playback. Sync `_trackQueue` by awaiting `_player.stream.playlist.first` after the command. Store `_originalQueue` for unshuffle.
 25. **"The utility row has 6 icons."** No. It's 4: Lyrics, Save, Queue, More. Sleep timer, playback speed, audio output, and EQ are behind the More popup.
 26. **"Apply EQ/DSP via a separate audio pipeline."** No. Use `player.updateAudioEffects(AudioEffects(...))`. The engine handles DSP natively.
+27. **"Build a parallel HTTP client for Navidrome."** Don't build from scratch. Implement the `MusicBackend` interface in `SubsonicClient`. All providers already use `musicBackendProvider`.
+28. **"Use `jellyfinClientProvider` for backend operations."** No. Use `musicBackendProvider` — it returns the correct client (Jellyfin or Subsonic) based on `auth.serverType`. `jellyfinClientProvider` is only for Jellyfin-specific operations like `publicInfo()` and `authenticate()`.
+29. **"Store the Subsonic auth token."** No. Store the **password** in `accessToken` (encrypted in secure storage). The token is `md5(password + salt)` and must be recomputed per request with a fresh random salt.
+30. **"Reuse a Subsonic salt across requests."** No. Each request generates a fresh random salt to prevent replay attacks.
+31. **"Navidrome supports all Jellyfin endpoints."** No. Subsonic API has gaps: no `resumeItems` equivalent (returns empty), no `movePlaylistItem` (no-op), no API key auth (always username + password).
 
 ## 16. Glossary
 
@@ -564,6 +643,12 @@ PII (usernames, server URLs) must be redacted in release builds.
 - **`ReplayGainMode`**: mpv_audio_kit enum for ReplayGain behavior (off, track, album). Set via `setReplayGain`, observed via `replayGainStream`.
 - **`_originalQueue`**: Field in `AfPlayerService` storing the unshuffled track order. Restored when shuffle is toggled off via mpv's `playlist-unshuffle`.
 - **`playNext()` / `addToQueue()`**: `AfPlayerService` methods for inserting tracks relative to the current position. Used by long-press context menus on track rows and album tiles.
+- **`MusicBackend`**: Abstract interface (`lib/core/backend/music_backend.dart`) defining all server operations. `JellyfinClient` and `SubsonicClient` both implement it. Providers use `musicBackendProvider` to get the active backend.
+- **`musicBackendProvider`**: Riverpod provider that creates the correct `MusicBackend` implementation based on `auth.serverType`. Replaced `jellyfinClientProvider` as the primary backend accessor.
+- **`SubsonicClient`**: HTTP client for Navidrome/Subsonic servers (`lib/core/subsonic/client.dart`). Uses token auth (`md5(password + salt)`) with random salt per request. Implements `MusicBackend`.
+- **`ServerType`**: Enum (`jellyfin` | `subsonic`) persisted in auth storage. Determines which client `musicBackendProvider` instantiates. Defined in `lib/core/jellyfin/models/server.dart`, re-exported from `music_backend.dart`.
+- **`SubsonicApiError`**: Exception thrown by `SubsonicClient` when the Subsonic API returns a non-OK status in its response envelope.
+- **Subsonic token auth**: Authentication scheme used by Navidrome. Token = `md5(password + salt)`. Sent as query params `u`, `t`, `s` on every request. Password stored in `JellyfinAuth.accessToken`.
 
 ---
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,8 +6,8 @@
 **Repository:** <https://github.com/Aetherfin/mobile-app>
 
 Short version: **Aetherfin does not collect, transmit, or sell any
-personal data.** It is a client that talks only to the Jellyfin server
-you configure. Everything else stays on your phone.
+personal data.** It is a client that talks only to the Jellyfin or
+Navidrome server you configure. Everything else stays on your phone.
 
 The rest of this document explains what data the App handles, where it
 lives, and what we (the maintainer) do and do not see.
@@ -31,27 +31,30 @@ are out of scope of this policy.
 
 | Data | Where it lives | Who sees it |
 |---|---|---|
-| Jellyfin **server URL** (e.g. `http://omahsangar.local:8097`) | `flutter_secure_storage` on your device | You + your Jellyfin server |
-| Jellyfin **username** | `flutter_secure_storage` on your device | You + your Jellyfin server |
-| Jellyfin **access token** (issued by your server on sign-in) | `flutter_secure_storage` on your device | You + your Jellyfin server |
-| Jellyfin **user ID** | `flutter_secure_storage` on your device | You + your Jellyfin server |
-| **Device ID** — random 16-byte value generated on first launch and used as Jellyfin's `DeviceId` for session bookkeeping | `flutter_secure_storage` on your device | Your Jellyfin server |
+| **Server URL** (e.g. `http://omahsangar.local:8097` for Jellyfin, `http://192.168.1.10:4533` for Navidrome) | `flutter_secure_storage` on your device | You + your server |
+| **Username** | `flutter_secure_storage` on your device | You + your server |
+| **Access token** (Jellyfin) or **password** (Navidrome — stored encrypted, used to compute per-request auth tokens) | `flutter_secure_storage` on your device | You + your server |
+| **User ID** | `flutter_secure_storage` on your device | You + your server |
+| **Server type** (Jellyfin or Navidrome/Subsonic) | `flutter_secure_storage` on your device | Only you |
+| **Device ID** — random 16-byte value generated on first launch and used as Jellyfin's `DeviceId` for session bookkeeping | `flutter_secure_storage` on your device | Your server |
 | **Settings** (audio-quality preference, crossfade, sleep-timer state, sort order, theme overrides) | `shared_preferences` on your device | Only you |
 | **Cover-art image cache** | `cached_network_image` files in the App's private cache directory | Only you |
 | **HTTP cache** of catalog requests | Dio cache files in the App's private cache directory | Only you |
-| **Lyrics (LRC files)** fetched from your Jellyfin server | In-memory only — not persisted | Only you, while playing |
+| **Lyrics (LRC files)** fetched from your server | In-memory only — not persisted | Only you, while playing |
 | **Playback state** (current track, position, queue) | In-memory + lock-screen `MediaSession` | Only you |
 | **Diagnostic logs** (`aetherfin:boot`, `aetherfin:http`, `aetherfin:data`, `aetherfin:audio`, `aetherfin:error`) | Standard Android logcat buffer (volatile, capped by the OS) | Only you, when you run `adb logcat` |
 
 **Aetherfin does not send any of the above to the maintainer or any
 third party.** The only network destination Aetherfin contacts is the
-Jellyfin server URL you provide.
+server URL you provide (Jellyfin or Navidrome).
 
-## 3. What Aetherfin sends to your Jellyfin server
+## 3. What Aetherfin sends to your server
 
-The App is a client for the Jellyfin HTTP API. When you sign in and use
-the App it sends the same requests any Jellyfin client (Finamp, the
-official web client, etc.) would send, including:
+The App is a client for either the Jellyfin HTTP API or the Subsonic
+(Navidrome) API. When you sign in and use the App it sends the same
+requests any compatible client would send, including:
+
+### 3a. Jellyfin servers
 
 - **Authentication:** `POST /Users/AuthenticateByName` (your username
   and password) — sent only once per sign-in to obtain an access token.
@@ -69,10 +72,23 @@ official web client, etc.) would send, including:
     last-played-at timestamps are updated. These can be disabled by
     your Jellyfin server administrator if desired.
 
-Your Jellyfin server logs and stores this data according to its own
+### 3b. Navidrome (Subsonic API) servers
+
+- **Authentication:** Every request carries query parameters `u`
+  (username), `t` (`md5(password + salt)`), and `s` (random salt).
+  The password itself is never sent over the wire — only the hash.
+- **Catalog reads:** `getAlbumList2.view`, `getArtists.view`,
+  `getArtist.view`, `getAlbum.view`, `search3.view`, etc.
+- **Audio streaming:** `GET /rest/stream.view?id=…` — direct
+  byte-for-byte download of the audio file.
+- **Library state writes:**
+  - `star.view` / `unstar.view` when you tap the heart icon.
+  - `scrobble.view` to report playback for play counts.
+
+Your server logs and stores this data according to its own
 configuration, which is **outside the control of the App and its
-maintainer**. Refer to your Jellyfin server administrator for its
-retention and access policy.
+maintainer**. Refer to your server administrator for its retention
+and access policy.
 
 ## 4. What Aetherfin does NOT do
 
@@ -89,13 +105,14 @@ retention and access policy.
 
 You can verify this by reading the source code at
 <https://github.com/Aetherfin/mobile-app>. The full list of network
-endpoints the App touches is enumerated in `lib/core/jellyfin/client.dart`.
+endpoints the App touches is enumerated in `lib/core/jellyfin/client.dart`
+(Jellyfin) and `lib/core/subsonic/client.dart` (Navidrome).
 
 ## 5. Android permissions Aetherfin requests
 
 | Permission | Why |
 |---|---|
-| `INTERNET` | To talk to your Jellyfin server. |
+| `INTERNET` | To talk to your Jellyfin or Navidrome server. |
 | `ACCESS_NETWORK_STATE` | So the App can react to your phone being offline. |
 | `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` (Android 14+) | So music keeps playing when the App is backgrounded, via Android's standard media session. |
 | `WAKE_LOCK` | So the CPU stays awake long enough to decode the next chunk of audio when the screen is off. |
@@ -133,7 +150,9 @@ behavior — every HTTP call, every storage write — is visible at:
 If you want to verify the claims in this policy, the relevant files are:
 
 - `lib/core/jellyfin/client.dart` — the only file that issues HTTP
-  requests.
+  requests to Jellyfin.
+- `lib/core/subsonic/client.dart` — the only file that issues HTTP
+  requests to Navidrome (Subsonic API).
 - `lib/core/jellyfin/auth_storage.dart` — the secure-storage adapter.
 - `lib/state/providers.dart` — every data fetch the UI watches.
 - `lib/main.dart` — bootstrap and initialization.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -55,3 +55,9 @@
 - [x] Run `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
 - [x] Run `flutter test` — all 24 tests pass
 - [x] Push all changes to `navidrome` branch
+
+## Merge & Documentation
+- [x] Merge `navidrome` branch into `main`
+- [x] Update CLAUDE.md — multi-backend architecture, Subsonic auth, source-tree, glossary, AI gotchas
+- [x] Update README.md — Navidrome support, dual-backend architecture diagram, requirements
+- [x] Update PRIVACY.md — dual-backend data handling, Subsonic API section

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Aetherfin
 
 A native-feeling Android music player backed by your self-hosted
-[Jellyfin](https://jellyfin.org) server. Aetherfin is the player —
-Jellyfin is the file source.
+[Jellyfin](https://jellyfin.org) or [Navidrome](https://www.navidrome.org)
+server. Aetherfin is the player — the server is the file source.
 
 > Spotify's polish. Apple Music's typography. Soulseek's respect for the
 > listener.
@@ -16,10 +16,10 @@ Jellyfin is the file source.
 
 ## What it is
 
-Aetherfin streams music from a Jellyfin server you own and decodes it
-fully on-device using **libmpv** via
+Aetherfin streams music from a Jellyfin or Navidrome server you own and
+decodes it fully on-device using **libmpv** via
 [mpv_audio_kit](https://pub.dev/packages/mpv_audio_kit). No
-Aetherfin-operated servers exist. No telemetry. Jellyfin is treated as a
+Aetherfin-operated servers exist. No telemetry. The server is treated as a
 passive file source plus per-user state store (favorites, play counts,
 playlists). Everything else — buffering, decoding, queue management,
 lyrics, lock-screen controls, sleep timer, spectral color extraction,
@@ -27,12 +27,13 @@ real-time FFT visualizer — runs on your phone.
 
 **Why this matters**
 
-- The Jellyfin server's CPU stays cool. Tracks are served as raw bytes
-  via `/Audio/{id}/stream?Static=true`. No HLS transcoding round-trip.
+- The server's CPU stays cool. Tracks are served as raw bytes
+  (Jellyfin: `/Audio/{id}/stream?Static=true`; Navidrome: `/rest/stream.view`).
+  No HLS transcoding round-trip.
 - You can play lossless FLAC / ALAC / OPUS / WAV files without quality loss.
 - The FFT spectrum visualizer is driven by the actual audio output
   post-DSP — no `RECORD_AUDIO` permission needed.
-- Aetherfin keeps working as long as your Jellyfin server is reachable.
+- Aetherfin keeps working as long as your server is reachable.
   There is no "Aetherfin cloud" to depend on.
 
 ## Screenshots
@@ -80,6 +81,8 @@ real-time FFT visualizer — runs on your phone.
 - **Network & cache settings** — cache duration, buffer size, keep-audio-active toggle
 - **Save to playlist** / create playlist from Now Playing
 - **Playlist management** — reorder, remove, rename, delete
+- **Multi-backend support** — works with both **Jellyfin** and **Navidrome** (Subsonic API)
+- **Auto-detection** of server type during onboarding (Jellyfin publicInfo, then Subsonic ping)
 - **mDNS discovery** of Jellyfin servers on the local network
 - **Spectral-derived UI accents** — palette sampled from current cover art
 - **Gapless playback** — libmpv pre-fetches the next track in the background
@@ -92,8 +95,11 @@ real-time FFT visualizer — runs on your phone.
 ## Requirements
 
 - **Android 7.0 (API 24)** or newer.
-- A reachable [**Jellyfin 10.8+**](https://jellyfin.org/downloads/server)
-  server with at least one music library.
+- A reachable music server — either:
+  - [**Jellyfin 10.8+**](https://jellyfin.org/downloads/server), or
+  - [**Navidrome 0.49+**](https://www.navidrome.org/docs/installation/)
+    (or any Subsonic API v1.16.1+ compatible server)
+- At least one music library configured on the server.
 - Network reachability between phone and server (LAN, VPN, or
   publicly-exposed HTTPS — all work).
 
@@ -110,9 +116,11 @@ real-time FFT visualizer — runs on your phone.
 ### First-run onboarding
 
 1. **Discover or enter your server URL** (e.g. `http://192.168.1.10:8096`
-   or `https://music.example.com`). mDNS will list nearby Jellyfin
-   instances; otherwise type the URL manually.
-2. **Sign in** with your Jellyfin username and password.
+   for Jellyfin, `http://192.168.1.10:4533` for Navidrome, or
+   `https://music.example.com`). mDNS will list nearby Jellyfin
+   instances; otherwise type the URL manually. The app auto-detects
+   whether it's a Jellyfin or Navidrome server.
+2. **Sign in** with your username and password.
 3. **You're in.** Pick a track. It plays.
 
 ## Building from source
@@ -147,18 +155,19 @@ CI runs both on every PR. See
 
 ```
    ┌────────────────────────────────┐         ┌──────────────────────────────┐
-   │   Aetherfin (Android)          │         │   Your Jellyfin server       │
+   │   Aetherfin (Android)          │         │   Jellyfin or Navidrome      │
    │                                │         │                              │
-   │  libmpv (mpv_audio_kit) ◄──────┼─bytes───┤  /Audio/{id}/stream          │
-   │  Queue / shuffle / loop        │         │   ?Static=true&api_key=…     │
-   │  Gapless prefetch              │◄─meta───┤  /Users/{id}/Items …         │
-   │  FFT spectrum (post-DSP)       │         │  /Users/{id}/FavoriteItems   │
-   │  Lyrics parse + sync           │◄─image──┤  /Items/{id}/Images/Primary  │
+   │  libmpv (mpv_audio_kit) ◄──────┼─bytes───┤  Jellyfin: /Audio/{id}/stream│
+   │  Queue / shuffle / loop        │         │  Navidrome: /rest/stream.view│
+   │  Gapless prefetch              │◄─meta───┤  Albums, artists, tracks     │
+   │  FFT spectrum (post-DSP)       │         │  Favorites, playlists        │
+   │  Lyrics parse + sync           │◄─image──┤  Cover art                   │
    │  Lock-screen (audio_service)   │         │                              │
    │  Cover-art file cache          │         │                              │
    │                                │         │                              │
    │  Optimistic favorite UI ───────┼─POST────┤  (server is source of truth) │
-   │  Telemetry (display only) ─────┼─POST────┤  /Sessions/Playing[/Progress]│
+   │  Telemetry (display only) ─────┼─POST────┤  Jellyfin: /Sessions/Playing │
+   │                                │         │  Navidrome: scrobble.view    │
    └────────────────────────────────┘         └──────────────────────────────┘
 ```
 
@@ -177,8 +186,8 @@ Full architectural rules live in [`CLAUDE.md`](./CLAUDE.md).
 ## Privacy
 
 Aetherfin does not operate any servers. The app talks only to the
-Jellyfin server you configure. Credentials live in Android's secure
-storage on the device. No analytics, no crash-reporting SDK, no ads,
+Jellyfin or Navidrome server you configure. Credentials live in Android's
+secure storage on the device. No analytics, no crash-reporting SDK, no ads,
 no third-party trackers. Full statement in [PRIVACY.md](./PRIVACY.md).
 
 ## License
@@ -201,6 +210,8 @@ non-negotiable rules.
 
 - [Jellyfin](https://jellyfin.org) — the free software media system this
   app is built around.
+- [Navidrome](https://www.navidrome.org) — the lightweight, self-hosted
+  music server with Subsonic API compatibility.
 - [Finamp](https://github.com/jmshrv/finamp) — prior-art Jellyfin music
   client whose auth-header format we follow.
 - [mpv_audio_kit](https://pub.dev/packages/mpv_audio_kit) — the


### PR DESCRIPTION
- CLAUDE.md: expanded §1 description, §1.1 mental model for dual backends, §2 tech stack (crypto dep), §3 source-tree (backend/ + subsonic/), §5.4 Subsonic auth, §5.5 server detection, §13 data layer conventions, §15 AI gotchas (#27-31), §16 glossary (MusicBackend, SubsonicClient, etc.)
- README.md: Navidrome in intro/features/requirements/onboarding/architecture, updated diagram, added Navidrome to acknowledgements
- PRIVACY.md: dual-backend data table, §3 split into Jellyfin + Subsonic sections, updated permissions and verifiable files
- PROGRESS.md: added merge & documentation section