### PR TITLE
fix: prevent visualizer scrubber and ring from disappearing on track skip

### DIFF
--- a/lib/widgets/audio_visual_scrubber.dart
+++ b/lib/widgets/audio_visual_scrubber.dart
@@ -331,7 +331,13 @@ class _CombinedBarPainter extends CustomPainter {
     final double midY    = size.height / 2;
     final double slotW   = size.width / _BlockNotifier.bins;
     final double barW    = (slotW * 0.7).clamp(1.0, 8.0);
-    final double fillX   = scrubNotifier.displayProgress * size.width;
+    final double rawFillX = scrubNotifier.displayProgress * size.width;
+    // When FFT bars are active (music is playing), ensure at least the
+    // first bar slot is colored so the visualizer doesn't go fully grey
+    // when position briefly resets to 0 during track transitions.
+    final double fillX   = fftNotifier.hasEnergy
+        ? math.max(rawFillX, slotW * 0.75)
+        : rawFillX;
     final double maxBarH = midY * 0.8;
     final barRadius      = Radius.circular(barW / 2);
 
@@ -438,7 +444,9 @@ class _ScrubOverlayPainter extends CustomPainter {
     // rather than just a soft glow. Layers: outer glow → horizontal
     // streak → vertical cross-streak → white-hot core.
     {
-      final cx     = fillW; // clamped to [0, size.width] above
+      // Ensure the playhead center is at least the core radius from the
+      // left edge so glow effects aren't clipped by Stack.hardEdge.
+      final cx     = math.max(fillW, 2.5);
       final isDrag = notifier.dragging;
 
       // Outer ambient glow (soft, wide).

--- a/lib/widgets/circular_progress_ring.dart
+++ b/lib/widgets/circular_progress_ring.dart
@@ -107,17 +107,18 @@ class _RingPainter extends CustomPainter {
       fg..style = PaintingStyle.fill,
     );
 
-    if (progress > 0.001) {
-      canvas.drawArc(
-        Rect.fromCircle(center: center, radius: radius),
-        -math.pi / 2,
-        2 * math.pi * progress,
-        false,
-        fg
-          ..style = PaintingStyle.stroke
-          ..strokeCap = StrokeCap.round,
-      );
-    }
+    // Always draw at least a tiny arc so the ring never appears empty
+    // when position briefly resets to 0 during track transitions.
+    final sweepProgress = math.max(progress, 0.005);
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      -math.pi / 2,
+      2 * math.pi * sweepProgress,
+      false,
+      fg
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round,
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

Fixes the bug where the progress bar, visualizer bar colors, and mini-player circular ring all visually disappear when pressing next/previous or when a song starts playing. The root cause is that position resets to 0 for the new track, which cascades through three painters:

1. **`_CombinedBarPainter`** (`audio_visual_scrubber.dart`): `fillX = 0` meant every bar center `(i+0.5)*slotW` was greater than `fillX`, so ALL 64 bars were rendered in `unplayedColor` (grey). Fix: when FFT energy is active, clamp `fillX` to a minimum of `0.75 * slotW` so the first bar retains the spectral color during track transitions.

2. **`_ScrubOverlayPainter`** (`audio_visual_scrubber.dart`): Playhead at `cx = fillW = 0` was half-clipped by `Stack.hardEdge`. Fix: clamp `cx` to at least `2.5` so glow effects are fully visible at position 0.

3. **`_RingPainter`** (`circular_progress_ring.dart`): Arc was gated by `progress > 0.001`, so at position 0 only a tiny 1px dot remained. Fix: always draw at least a 0.5% arc so the ring retains a visible indicator during brief position resets.

## Review & Testing Checklist for Human

- [ ] **Play a song, press next**: Verify the visualizer bars retain spectral color and the scrubber playhead stays visible during track transition
- [ ] **Seek to position 0**: Drag the scrubber all the way left — confirm the playhead glow is visible and at least the first bar is colored
- [ ] **Mini-player ring**: After pressing next, verify the circular ring does not go completely empty
- [ ] **Normal playback**: Verify no visual regression during normal playback, seeking mid-track, and reaching end of track

### Notes

- All three fixes are minimal and localized to the paint methods — no state management or stream changes
- `flutter analyze` passes with no issues
- All 27 existing tests pass