### PR TITLE
feat: full audio DSP/effects rack + expanded ReplayGain, Gapless, and Prefetch settings

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -72,37 +72,40 @@
     No pre-DSP tap available in the library. Documenting as known limitation.
 
 ## Equalizer & DSP UI (now_playing_screen.dart)
-- [x] Bass shelf (+/- 12 dB) — already implemented
-- [x] Treble shelf (+/- 12 dB) — already implemented
-- [x] Loudness normalization (EBU R128) toggle — already implemented
-- [x] Dynamic compressor toggle — already implemented
-- [ ] 18-band Superequalizer (ISO graphic EQ)
-- [ ] Rubberband pitch & tempo shifting
-- [ ] Crossfeed (headphone)
-- [ ] Stereo widening
-- [ ] Harmonic exciter
-- [ ] Noise gate
-- [ ] Echo / delay
-- [ ] Virtualizer (virtual bass)
-- [ ] Crystalizer (audio sharpener)
-- [ ] De-esser
+- [x] Bass shelf (+/- 12 dB)
+- [x] Treble shelf (+/- 12 dB)
+- [x] Loudness normalization (EBU R128) toggle
+- [x] Dynamic compressor toggle
+- [x] 18-band Superequalizer (ISO graphic EQ) — per-band sliders, 0..4 linear gain
+- [x] Rubberband pitch & tempo shifting — 0.5x..2.0x sliders
+- [x] Crossfeed (headphone) — strength slider
+- [x] Stereo widening — delay slider
+- [x] Harmonic exciter — amount slider
+- [x] Noise gate — toggle
+- [x] Virtual bass — cutoff slider
+- [x] Crystalizer (audio sharpener) — intensity slider
+- [x] De-esser — toggle
+- [x] Reset all button — clears every effect
+- [x] Dialog refactored to DraggableScrollableSheet (bottom sheet)
 
 ## ReplayGain (settings_screen.dart)
-- [x] Mode picker (Off / Track / Album) — already implemented
-- [ ] Preamp adjustment (dB slider)
-- [ ] Fallback gain (dB slider)
-- [ ] Clip prevention toggle
+- [x] Mode picker (Off / Track / Album)
+- [x] Preamp adjustment (-15..+15 dB slider)
+- [x] Fallback gain (-15..0 dB slider)
+- [x] Clip prevention toggle
 
 ## Gapless & Prefetch (settings_screen.dart)
-- [x] Gapless mode set to `weak` by default — already implemented
-- [ ] Gapless mode picker (Yes / Weak / No) in settings UI
-- [ ] Prefetch playlist toggle in settings UI
+- [x] Gapless mode picker (Full / Weak / Off)
+- [x] Prefetch next track toggle
 
 ## Persistence
 - [x] ReplayGain mode — persisted via PlayerSettingsStore
+- [x] ReplayGain preamp, fallback, clip — persisted
 - [x] Gapless mode — persisted via PlayerSettingsStore
-- [ ] Audio effects bundle — persist via PlayerSettingsStore
+- [x] Prefetch playlist — persisted via PlayerSettingsStore
+- [x] Audio effects bundle — JSON-serialized to shared_preferences
+- [x] All settings restored on app startup via applyPersisted()
 
 ## Quality
-- [ ] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
-- [ ] `flutter test` — all tests pass
+- [x] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
+- [x] `flutter test` — all 24 tests pass

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -61,3 +61,48 @@
 - [x] Update CLAUDE.md — multi-backend architecture, Subsonic auth, source-tree, glossary, AI gotchas
 - [x] Update README.md — Navidrome support, dual-backend architecture diagram, requirements
 - [x] Update PRIVACY.md — dual-backend data handling, Subsonic API section
+
+---
+
+# Audio DSP & Effects — Progress
+
+## Visualizer DSP Bypass
+- [ ] Make FFT spectrum ignore audio effects (pre-DSP tap)
+  - Note: `mpv_audio_kit` 0.1.3 spectrum is post-DSP (`pcm-tap-frame`).
+    No pre-DSP tap available in the library. Documenting as known limitation.
+
+## Equalizer & DSP UI (now_playing_screen.dart)
+- [x] Bass shelf (+/- 12 dB) — already implemented
+- [x] Treble shelf (+/- 12 dB) — already implemented
+- [x] Loudness normalization (EBU R128) toggle — already implemented
+- [x] Dynamic compressor toggle — already implemented
+- [ ] 18-band Superequalizer (ISO graphic EQ)
+- [ ] Rubberband pitch & tempo shifting
+- [ ] Crossfeed (headphone)
+- [ ] Stereo widening
+- [ ] Harmonic exciter
+- [ ] Noise gate
+- [ ] Echo / delay
+- [ ] Virtualizer (virtual bass)
+- [ ] Crystalizer (audio sharpener)
+- [ ] De-esser
+
+## ReplayGain (settings_screen.dart)
+- [x] Mode picker (Off / Track / Album) — already implemented
+- [ ] Preamp adjustment (dB slider)
+- [ ] Fallback gain (dB slider)
+- [ ] Clip prevention toggle
+
+## Gapless & Prefetch (settings_screen.dart)
+- [x] Gapless mode set to `weak` by default — already implemented
+- [ ] Gapless mode picker (Yes / Weak / No) in settings UI
+- [ ] Prefetch playlist toggle in settings UI
+
+## Persistence
+- [x] ReplayGain mode — persisted via PlayerSettingsStore
+- [x] Gapless mode — persisted via PlayerSettingsStore
+- [ ] Audio effects bundle — persist via PlayerSettingsStore
+
+## Quality
+- [ ] `flutter analyze --no-fatal-infos` — 0 errors, 0 warnings
+- [ ] `flutter test` — all tests pass

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -357,6 +357,10 @@ class AfPlayerService extends BaseAudioHandler
   /// Real-time FFT spectrum — 64 log-spaced bands in [0, 1] at ~30 fps.
   /// No RECORD_AUDIO permission needed. Lazy: pipeline starts on first
   /// listener, stops on last cancel.
+  ///
+  /// Captured post-DSP (mpv `pcm-tap-frame`). A pre-DSP tap is not
+  /// available in mpv_audio_kit 0.1.3; the visualizer therefore
+  /// reflects processed audio when effects are active.
   Stream<FftFrame> get spectrumStream => _player.stream.spectrum;
 
   /// Configure the spectrum pipeline for visualizer use.

--- a/lib/core/audio/player_settings_store.dart
+++ b/lib/core/audio/player_settings_store.dart
@@ -1,5 +1,5 @@
 import 'package:mpv_audio_kit/mpv_audio_kit.dart'
-    show Cache, Format, Gapless, ReplayGain;
+    show Cache, Format, Gapless, ReplayGain, ReplayGainSettings;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../utils/log.dart';
@@ -36,6 +36,11 @@ class PlayerSettingsStore {
   static const _kCacheSecs = 'af.cache_secs';
   static const _kReplayGain = 'af.replay_gain_mode';
   static const _kGapless = 'af.gapless';
+  static const _kReplayGainPreamp = 'af.replay_gain_preamp';
+  static const _kReplayGainFallback = 'af.replay_gain_fallback';
+  static const _kReplayGainClip = 'af.replay_gain_clip';
+  static const _kPrefetchPlaylist = 'af.prefetch_playlist';
+  static const _kAudioEffects = 'af.audio_effects_json';
 
   static Future<SharedPreferences> _prefs() => SharedPreferences.getInstance();
 
@@ -74,6 +79,19 @@ class PlayerSettingsStore {
   static Future<void> saveReplayGain(ReplayGain mode) async {
     final p = await _prefs();
     await p.setString(_kReplayGain, mode.name);
+  }
+
+  static Future<void> saveReplayGainFull(ReplayGainSettings settings) async {
+    final p = await _prefs();
+    await p.setString(_kReplayGain, settings.mode.name);
+    await p.setDouble(_kReplayGainPreamp, settings.preamp);
+    await p.setDouble(_kReplayGainFallback, settings.fallback);
+    await p.setBool(_kReplayGainClip, settings.clip);
+  }
+
+  static Future<void> savePrefetchPlaylist(bool enabled) async {
+    final p = await _prefs();
+    await p.setBool(_kPrefetchPlaylist, enabled);
   }
 
   static Future<void> saveGapless(Gapless mode) async {
@@ -148,8 +166,16 @@ class PlayerSettingsStore {
         (m) => m.name == replayGainName,
         orElse: () => ReplayGain.no,
       );
+      final preamp = p.getDouble(_kReplayGainPreamp) ?? 0.0;
+      final fallback = p.getDouble(_kReplayGainFallback) ?? 0.0;
+      final clip = p.getBool(_kReplayGainClip) ?? false;
       await tryApply('replayGain=$replayGainName', () async {
-        await svc.setReplayGain(svc.replayGain.copyWith(mode: mode));
+        await svc.setReplayGain(ReplayGainSettings(
+          mode: mode,
+          preamp: preamp,
+          fallback: fallback,
+          clip: clip,
+        ));
       });
     }
 
@@ -160,6 +186,12 @@ class PlayerSettingsStore {
         orElse: () => Gapless.weak,
       );
       await tryApply('gapless=$gaplessName', () => svc.setGapless(mode));
+    }
+
+    final prefetch = p.getBool(_kPrefetchPlaylist);
+    if (prefetch != null) {
+      await tryApply('prefetchPlaylist=$prefetch',
+          () => svc.setPrefetchPlaylist(prefetch));
     }
 
     afLog('boot', 'PlayerSettingsStore applied persisted settings');

--- a/lib/core/audio/player_settings_store.dart
+++ b/lib/core/audio/player_settings_store.dart
@@ -1,5 +1,26 @@
+import 'dart:convert';
+
 import 'package:mpv_audio_kit/mpv_audio_kit.dart'
-    show Cache, Format, Gapless, ReplayGain, ReplayGainSettings;
+    show
+        AcompressorSettings,
+        AexciterSettings,
+        AgateSettings,
+        AudioEffects,
+        BassSettings,
+        Cache,
+        CrossfeedSettings,
+        CrystalizerSettings,
+        DeesserSettings,
+        Format,
+        Gapless,
+        LoudnormSettings,
+        ReplayGain,
+        ReplayGainSettings,
+        RubberbandSettings,
+        StereowidenSettings,
+        SuperequalizerSettings,
+        TrebleSettings,
+        VirtualbassSettings;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../utils/log.dart';
@@ -99,6 +120,112 @@ class PlayerSettingsStore {
     await p.setString(_kGapless, mode.name);
   }
 
+  /// Serialize the user-visible audio effects to JSON and persist.
+  static Future<void> saveAudioEffects(AudioEffects fx) async {
+    final p = await _prefs();
+    final map = <String, dynamic>{
+      'bass_g': fx.bass.g,
+      'bass_enabled': fx.bass.enabled,
+      'treble_g': fx.treble.g,
+      'treble_enabled': fx.treble.enabled,
+      'loudnorm_enabled': fx.loudnorm.enabled,
+      'compressor_enabled': fx.acompressor.enabled,
+      'compressor_threshold': fx.acompressor.threshold,
+      'compressor_ratio': fx.acompressor.ratio,
+      'compressor_attack': fx.acompressor.attack,
+      'compressor_release': fx.acompressor.release,
+      'eq_enabled': fx.superequalizer.enabled,
+      'eq_params': fx.superequalizer.params,
+      'rubberband_enabled': fx.rubberband.enabled,
+      'rubberband_pitch': fx.rubberband.pitch,
+      'rubberband_tempo': fx.rubberband.tempo,
+      'crossfeed_enabled': fx.crossfeed.enabled,
+      'crossfeed_strength': fx.crossfeed.strength,
+      'stereowiden_enabled': fx.stereowiden.enabled,
+      'stereowiden_delay': fx.stereowiden.delay,
+      'exciter_enabled': fx.aexciter.enabled,
+      'exciter_amount': fx.aexciter.amount,
+      'crystalizer_enabled': fx.crystalizer.enabled,
+      'crystalizer_i': fx.crystalizer.i,
+      'virtualbass_enabled': fx.virtualbass.enabled,
+      'virtualbass_cutoff': fx.virtualbass.cutoff,
+      'gate_enabled': fx.agate.enabled,
+      'deesser_enabled': fx.deesser.enabled,
+    };
+    await p.setString(_kAudioEffects, jsonEncode(map));
+  }
+
+  /// Restore audio effects from JSON.
+  static AudioEffects? loadAudioEffects(SharedPreferences p) {
+    final json = p.getString(_kAudioEffects);
+    if (json == null) return null;
+    try {
+      final m = jsonDecode(json) as Map<String, dynamic>;
+      final eqParamsRaw = m['eq_params'] as Map<String, dynamic>?;
+      final eqParams = eqParamsRaw?.map(
+            (k, v) => MapEntry(k, (v as num).toDouble()),
+          ) ??
+          const <String, double>{};
+      return AudioEffects(
+        bass: BassSettings(
+          enabled: m['bass_enabled'] as bool? ?? false,
+          g: (m['bass_g'] as num?)?.toDouble() ?? 0.0,
+        ),
+        treble: TrebleSettings(
+          enabled: m['treble_enabled'] as bool? ?? false,
+          g: (m['treble_g'] as num?)?.toDouble() ?? 0.0,
+        ),
+        loudnorm: LoudnormSettings(
+          enabled: m['loudnorm_enabled'] as bool? ?? false,
+        ),
+        acompressor: AcompressorSettings(
+          enabled: m['compressor_enabled'] as bool? ?? false,
+          threshold: (m['compressor_threshold'] as num?)?.toDouble() ?? 0.1,
+          ratio: (m['compressor_ratio'] as num?)?.toDouble() ?? 4.0,
+          attack: (m['compressor_attack'] as num?)?.toDouble() ?? 20.0,
+          release: (m['compressor_release'] as num?)?.toDouble() ?? 250.0,
+        ),
+        superequalizer: SuperequalizerSettings(
+          enabled: m['eq_enabled'] as bool? ?? false,
+          params: eqParams,
+        ),
+        rubberband: RubberbandSettings(
+          enabled: m['rubberband_enabled'] as bool? ?? false,
+          pitch: (m['rubberband_pitch'] as num?)?.toDouble() ?? 1.0,
+          tempo: (m['rubberband_tempo'] as num?)?.toDouble() ?? 1.0,
+        ),
+        crossfeed: CrossfeedSettings(
+          enabled: m['crossfeed_enabled'] as bool? ?? false,
+          strength: (m['crossfeed_strength'] as num?)?.toDouble() ?? 0.2,
+        ),
+        stereowiden: StereowidenSettings(
+          enabled: m['stereowiden_enabled'] as bool? ?? false,
+          delay: (m['stereowiden_delay'] as num?)?.toDouble() ?? 20.0,
+        ),
+        aexciter: AexciterSettings(
+          enabled: m['exciter_enabled'] as bool? ?? false,
+          amount: (m['exciter_amount'] as num?)?.toDouble() ?? 1.0,
+        ),
+        crystalizer: CrystalizerSettings(
+          enabled: m['crystalizer_enabled'] as bool? ?? false,
+          i: (m['crystalizer_i'] as num?)?.toDouble() ?? 2.0,
+        ),
+        virtualbass: VirtualbassSettings(
+          enabled: m['virtualbass_enabled'] as bool? ?? false,
+          cutoff: (m['virtualbass_cutoff'] as num?)?.toDouble() ?? 250.0,
+        ),
+        agate: AgateSettings(
+          enabled: m['gate_enabled'] as bool? ?? false,
+        ),
+        deesser: DeesserSettings(
+          enabled: m['deesser_enabled'] as bool? ?? false,
+        ),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
   // ── Apply on startup ──────────────────────────────────────────────────────
 
   /// Reads every persisted key and replays the matching setter on [svc].
@@ -192,6 +319,11 @@ class PlayerSettingsStore {
     if (prefetch != null) {
       await tryApply('prefetchPlaylist=$prefetch',
           () => svc.setPrefetchPlaylist(prefetch));
+    }
+
+    final fx = loadAudioEffects(p);
+    if (fx != null) {
+      await tryApply('audioEffects', () => svc.setAudioEffects(fx));
     }
 
     afLog('boot', 'PlayerSettingsStore applied persisted settings');

--- a/lib/features/now_playing/now_playing_screen.dart
+++ b/lib/features/now_playing/now_playing_screen.dart
@@ -23,6 +23,7 @@ import 'package:mpv_audio_kit/mpv_audio_kit.dart'
         VirtualbassSettings;
 
 import '../../core/audio/play_actions.dart';
+import '../../core/audio/player_settings_store.dart';
 import '../../core/backend/music_backend.dart';
 import '../../core/jellyfin/models/items.dart';
 import '../../design_tokens/tokens.dart';
@@ -1079,49 +1080,51 @@ class _EqDialogContentState extends ConsumerState<_EqDialogContent> {
 
   void _apply() {
     final svc = ref.read(playerServiceProvider);
-    unawaited(svc.updateAudioEffects((e) => e.copyWith(
-          bass: BassSettings(enabled: _bass != 0, g: _bass),
-          treble: TrebleSettings(enabled: _treble != 0, g: _treble),
-          loudnorm: LoudnormSettings(enabled: _loudnorm),
-          acompressor: AcompressorSettings(
-            enabled: _compressor,
-            threshold: 0.1,
-            ratio: 4.0,
-            attack: 20.0,
-            release: 250.0,
-          ),
-          superequalizer: SuperequalizerSettings(
-            enabled: _eqEnabled,
-            params: _buildEqParams(),
-          ),
-          rubberband: RubberbandSettings(
-            enabled: _rubberbandEnabled,
-            pitch: _pitch,
-            tempo: _tempo,
-          ),
-          crossfeed: CrossfeedSettings(
-            enabled: _crossfeed,
-            strength: _crossfeedStrength,
-          ),
-          stereowiden: StereowidenSettings(
-            enabled: _stereoWiden,
-            delay: _stereoWidenDelay,
-          ),
-          aexciter: AexciterSettings(
-            enabled: _exciter,
-            amount: _exciterAmount,
-          ),
-          crystalizer: CrystalizerSettings(
-            enabled: _crystalizer,
-            i: _crystalizerIntensity,
-          ),
-          virtualbass: VirtualbassSettings(
-            enabled: _virtualBass,
-            cutoff: _virtualBassCutoff,
-          ),
-          agate: AgateSettings(enabled: _gate),
-          deesser: DeesserSettings(enabled: _deesser),
-        )));
+    final effects = AudioEffects(
+      bass: BassSettings(enabled: _bass != 0, g: _bass),
+      treble: TrebleSettings(enabled: _treble != 0, g: _treble),
+      loudnorm: LoudnormSettings(enabled: _loudnorm),
+      acompressor: AcompressorSettings(
+        enabled: _compressor,
+        threshold: 0.1,
+        ratio: 4.0,
+        attack: 20.0,
+        release: 250.0,
+      ),
+      superequalizer: SuperequalizerSettings(
+        enabled: _eqEnabled,
+        params: _buildEqParams(),
+      ),
+      rubberband: RubberbandSettings(
+        enabled: _rubberbandEnabled,
+        pitch: _pitch,
+        tempo: _tempo,
+      ),
+      crossfeed: CrossfeedSettings(
+        enabled: _crossfeed,
+        strength: _crossfeedStrength,
+      ),
+      stereowiden: StereowidenSettings(
+        enabled: _stereoWiden,
+        delay: _stereoWidenDelay,
+      ),
+      aexciter: AexciterSettings(
+        enabled: _exciter,
+        amount: _exciterAmount,
+      ),
+      crystalizer: CrystalizerSettings(
+        enabled: _crystalizer,
+        i: _crystalizerIntensity,
+      ),
+      virtualbass: VirtualbassSettings(
+        enabled: _virtualBass,
+        cutoff: _virtualBassCutoff,
+      ),
+      agate: AgateSettings(enabled: _gate),
+      deesser: DeesserSettings(enabled: _deesser),
+    );
+    unawaited(svc.setAudioEffects(effects));
+    unawaited(PlayerSettingsStore.saveAudioEffects(effects));
   }
 
   void _resetAll() {

--- a/lib/features/now_playing/now_playing_screen.dart
+++ b/lib/features/now_playing/now_playing_screen.dart
@@ -4,7 +4,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mpv_audio_kit/mpv_audio_kit.dart'
-    show AcompressorSettings, AudioEffects, BassSettings, Device, LoudnormSettings, Loop, TrebleSettings;
+    show
+        AcompressorSettings,
+        AexciterSettings,
+        AgateSettings,
+        AudioEffects,
+        BassSettings,
+        CrossfeedSettings,
+        CrystalizerSettings,
+        DeesserSettings,
+        Device,
+        LoudnormSettings,
+        Loop,
+        RubberbandSettings,
+        StereowidenSettings,
+        SuperequalizerSettings,
+        TrebleSettings,
+        VirtualbassSettings;
 
 import '../../core/audio/play_actions.dart';
 import '../../core/backend/music_backend.dart';
@@ -769,12 +785,21 @@ class _UtilityRow extends ConsumerWidget {
   }
 
   void _showEqDialog(BuildContext context, WidgetRef ref) {
-    showDialog<void>(
+    showModalBottomSheet<void>(
       context: context,
-      builder: (dialogCtx) => Dialog(
-        backgroundColor: AfColors.surfaceBase,
-        shape: RoundedRectangleBorder(borderRadius: AfRadii.borderLg),
-        child: _EqDialogContent(),
+      isScrollControlled: true,
+      backgroundColor: AfColors.surfaceBase,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => DraggableScrollableSheet(
+        initialChildSize: 0.85,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (_, controller) => _EqDialogContent(
+          scrollController: controller,
+        ),
       ),
     );
   }
@@ -953,16 +978,73 @@ class _MoreItem extends StatelessWidget {
 // Equalizer & DSP dialog
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// ISO 18-band center frequencies for the superequalizer.
+const _kEqBands = <String, String>{
+  '1b': '65 Hz',
+  '2b': '92 Hz',
+  '3b': '131 Hz',
+  '4b': '185 Hz',
+  '5b': '262 Hz',
+  '6b': '370 Hz',
+  '7b': '523 Hz',
+  '8b': '740 Hz',
+  '9b': '1.0 kHz',
+  '10b': '1.5 kHz',
+  '11b': '2.1 kHz',
+  '12b': '2.9 kHz',
+  '13b': '4.2 kHz',
+  '14b': '5.9 kHz',
+  '15b': '8.3 kHz',
+  '16b': '11.8 kHz',
+  '17b': '16.7 kHz',
+  '18b': '20 kHz',
+};
+
 class _EqDialogContent extends ConsumerStatefulWidget {
+  const _EqDialogContent({required this.scrollController});
+  final ScrollController scrollController;
+
   @override
   ConsumerState<_EqDialogContent> createState() => _EqDialogContentState();
 }
 
 class _EqDialogContentState extends ConsumerState<_EqDialogContent> {
+  // ── Tone ──
   double _bass = 0.0;
   double _treble = 0.0;
+
+  // ── Dynamics ──
   bool _loudnorm = false;
   bool _compressor = false;
+
+  // ── 18-band EQ (linear gain; 1.0 = flat, range 0–20) ──
+  bool _eqEnabled = false;
+  final Map<String, double> _eqBands = {
+    for (final k in _kEqBands.keys) k: 1.0,
+  };
+
+  // ── Pitch & tempo ──
+  bool _rubberbandEnabled = false;
+  double _pitch = 1.0;
+  double _tempo = 1.0;
+
+  // ── Spatial ──
+  bool _crossfeed = false;
+  double _crossfeedStrength = 0.2;
+  bool _stereoWiden = false;
+  double _stereoWidenDelay = 20.0;
+
+  // ── Creative ──
+  bool _exciter = false;
+  double _exciterAmount = 1.0;
+  bool _crystalizer = false;
+  double _crystalizerIntensity = 2.0;
+  bool _virtualBass = false;
+  double _virtualBassCutoff = 250.0;
+
+  // ── Cleanup ──
+  bool _gate = false;
+  bool _deesser = false;
 
   @override
   void initState() {
@@ -972,6 +1054,27 @@ class _EqDialogContentState extends ConsumerState<_EqDialogContent> {
     _treble = fx.treble.g;
     _loudnorm = fx.loudnorm.enabled;
     _compressor = fx.acompressor.enabled;
+    _eqEnabled = fx.superequalizer.enabled;
+    for (final entry in fx.superequalizer.params.entries) {
+      if (_eqBands.containsKey(entry.key)) {
+        _eqBands[entry.key] = entry.value;
+      }
+    }
+    _rubberbandEnabled = fx.rubberband.enabled;
+    _pitch = fx.rubberband.pitch;
+    _tempo = fx.rubberband.tempo;
+    _crossfeed = fx.crossfeed.enabled;
+    _crossfeedStrength = fx.crossfeed.strength;
+    _stereoWiden = fx.stereowiden.enabled;
+    _stereoWidenDelay = fx.stereowiden.delay;
+    _exciter = fx.aexciter.enabled;
+    _exciterAmount = fx.aexciter.amount;
+    _crystalizer = fx.crystalizer.enabled;
+    _crystalizerIntensity = fx.crystalizer.i.clamp(-10.0, 10.0);
+    _virtualBass = fx.virtualbass.enabled;
+    _virtualBassCutoff = fx.virtualbass.cutoff;
+    _gate = fx.agate.enabled;
+    _deesser = fx.deesser.enabled;
   }
 
   void _apply() {
@@ -987,133 +1090,505 @@ class _EqDialogContentState extends ConsumerState<_EqDialogContent> {
             attack: 20.0,
             release: 250.0,
           ),
+          superequalizer: SuperequalizerSettings(
+            enabled: _eqEnabled,
+            params: _buildEqParams(),
+          ),
+          rubberband: RubberbandSettings(
+            enabled: _rubberbandEnabled,
+            pitch: _pitch,
+            tempo: _tempo,
+          ),
+          crossfeed: CrossfeedSettings(
+            enabled: _crossfeed,
+            strength: _crossfeedStrength,
+          ),
+          stereowiden: StereowidenSettings(
+            enabled: _stereoWiden,
+            delay: _stereoWidenDelay,
+          ),
+          aexciter: AexciterSettings(
+            enabled: _exciter,
+            amount: _exciterAmount,
+          ),
+          crystalizer: CrystalizerSettings(
+            enabled: _crystalizer,
+            i: _crystalizerIntensity,
+          ),
+          virtualbass: VirtualbassSettings(
+            enabled: _virtualBass,
+            cutoff: _virtualBassCutoff,
+          ),
+          agate: AgateSettings(enabled: _gate),
+          deesser: DeesserSettings(enabled: _deesser),
         )));
+  }
+
+  void _resetAll() {
+    setState(() {
+      _bass = 0;
+      _treble = 0;
+      _loudnorm = false;
+      _compressor = false;
+      _eqEnabled = false;
+      for (final k in _eqBands.keys) {
+        _eqBands[k] = 1.0;
+      }
+      _rubberbandEnabled = false;
+      _pitch = 1.0;
+      _tempo = 1.0;
+      _crossfeed = false;
+      _crossfeedStrength = 0.2;
+      _stereoWiden = false;
+      _stereoWidenDelay = 20.0;
+      _exciter = false;
+      _exciterAmount = 1.0;
+      _crystalizer = false;
+      _crystalizerIntensity = 2.0;
+      _virtualBass = false;
+      _virtualBassCutoff = 250.0;
+      _gate = false;
+      _deesser = false;
+    });
+    unawaited(ref
+        .read(playerServiceProvider)
+        .setAudioEffects(const AudioEffects()));
   }
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return ListView(
+      controller: widget.scrollController,
       padding: const EdgeInsets.all(AfSpacing.gutterGenerous),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text('Equalizer & DSP', style: AfTypography.titleSmall),
-          const SizedBox(height: AfSpacing.s24),
-
-          // Bass shelf.
-          Row(
-            children: [
-              const Icon(Icons.graphic_eq_rounded,
-                  size: 18, color: AfColors.textSecondary),
-              const SizedBox(width: AfSpacing.s8),
-              Text('Bass', style: AfTypography.bodyMedium),
-              const Spacer(),
-              Text(
-                '${_bass > 0 ? "+" : ""}${_bass.toStringAsFixed(0)} dB',
-                style: AfTypography.mono.copyWith(
-                  color: AfColors.textTertiary,
-                ),
+      children: [
+        // Drag handle.
+        Center(
+          child: Container(
+            width: 32,
+            height: 4,
+            margin: const EdgeInsets.only(bottom: AfSpacing.s16),
+            decoration: BoxDecoration(
+              color: AfColors.textTertiary,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+        ),
+        Row(
+          children: [
+            Text('Equalizer & DSP', style: AfTypography.titleSmall),
+            const Spacer(),
+            TextButton(
+              onPressed: _resetAll,
+              child: Text(
+                'Reset all',
+                style: AfTypography.bodySmall
+                    .copyWith(color: AfColors.semanticError),
               ),
-            ],
-          ),
-          Slider(
-            value: _bass,
-            min: -12,
-            max: 12,
-            divisions: 24,
-            activeColor: AfColors.indigo400,
-            onChanged: (v) => setState(() => _bass = v),
-            onChangeEnd: (_) => _apply(),
-          ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AfSpacing.s16),
 
-          // Treble shelf.
-          Row(
-            children: [
-              const Icon(Icons.graphic_eq_rounded,
-                  size: 18, color: AfColors.textSecondary),
-              const SizedBox(width: AfSpacing.s8),
-              Text('Treble', style: AfTypography.bodyMedium),
-              const Spacer(),
-              Text(
-                '${_treble > 0 ? "+" : ""}${_treble.toStringAsFixed(0)} dB',
-                style: AfTypography.mono.copyWith(
-                  color: AfColors.textTertiary,
-                ),
+        // ── Tone shelves ───────────────────────────────────────────────
+        _sectionHeader('Tone'),
+        _sliderRow('Bass', _bass, -12, 12, 24, (v) {
+          setState(() => _bass = v);
+        }, _apply, suffix: 'dB'),
+        _sliderRow('Treble', _treble, -12, 12, 24, (v) {
+          setState(() => _treble = v);
+        }, _apply, suffix: 'dB'),
+
+        _divider(),
+
+        // ── 18-band graphic EQ ─────────────────────────────────────────
+        _sectionHeader('18-band Equalizer'),
+        SwitchListTile.adaptive(
+          value: _eqEnabled,
+          onChanged: (v) {
+            setState(() => _eqEnabled = v);
+            _apply();
+          },
+          title: Text('Enable graphic EQ', style: AfTypography.bodyMedium),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_eqEnabled) ..._buildEqBands(),
+        if (_eqEnabled)
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(
+              onPressed: () {
+                setState(() {
+                  for (final k in _eqBands.keys) {
+                    _eqBands[k] = 1.0;
+                  }
+                });
+                _apply();
+              },
+              child: Text(
+                'Flatten EQ',
+                style: AfTypography.bodySmall
+                    .copyWith(color: AfColors.textTertiary),
               ),
-            ],
-          ),
-          Slider(
-            value: _treble,
-            min: -12,
-            max: 12,
-            divisions: 24,
-            activeColor: AfColors.indigo400,
-            onChanged: (v) => setState(() => _treble = v),
-            onChangeEnd: (_) => _apply(),
-          ),
-
-          const SizedBox(height: AfSpacing.s8),
-          const Divider(height: 1, color: AfColors.surfaceHigh),
-          const SizedBox(height: AfSpacing.s8),
-
-          // Loudness normalization.
-          SwitchListTile.adaptive(
-            value: _loudnorm,
-            onChanged: (v) {
-              setState(() => _loudnorm = v);
-              _apply();
-            },
-            title: Text('Loudness normalization',
-                style: AfTypography.bodyMedium),
-            subtitle: Text(
-              'EBU R128 (-16 LUFS)',
-              style: AfTypography.bodySmall
-                  .copyWith(color: AfColors.textTertiary),
             ),
-            activeThumbColor: AfColors.indigo500,
-            contentPadding: EdgeInsets.zero,
           ),
 
-          // Compressor.
-          SwitchListTile.adaptive(
-            value: _compressor,
-            onChanged: (v) {
-              setState(() => _compressor = v);
-              _apply();
-            },
-            title: Text('Dynamic compressor', style: AfTypography.bodyMedium),
-            subtitle: Text(
-              'Reduces volume spikes',
-              style: AfTypography.bodySmall
-                  .copyWith(color: AfColors.textTertiary),
-            ),
-            activeThumbColor: AfColors.indigo500,
-            contentPadding: EdgeInsets.zero,
-          ),
+        _divider(),
 
-          const SizedBox(height: AfSpacing.s16),
-          TextButton(
-            onPressed: () {
-              setState(() {
-                _bass = 0;
-                _treble = 0;
-                _loudnorm = false;
-                _compressor = false;
-              });
-              unawaited(ref
-                  .read(playerServiceProvider)
-                  .setAudioEffects(const AudioEffects()));
-            },
-            child: Text(
-              'Reset all',
-              style: AfTypography.bodySmall
-                  .copyWith(color: AfColors.semanticError),
-            ),
+        // ── Dynamics ───────────────────────────────────────────────────
+        _sectionHeader('Dynamics'),
+        _toggleTile('Loudness normalization', 'EBU R128 (-16 LUFS)',
+            _loudnorm, (v) {
+          setState(() => _loudnorm = v);
+          _apply();
+        }),
+        _toggleTile(
+            'Dynamic compressor', 'Reduces volume spikes', _compressor, (v) {
+          setState(() => _compressor = v);
+          _apply();
+        }),
+        _toggleTile('Noise gate', 'Silences signal below threshold', _gate,
+            (v) {
+          setState(() => _gate = v);
+          _apply();
+        }),
+        _toggleTile('De-esser', 'Reduces sibilance', _deesser, (v) {
+          setState(() => _deesser = v);
+          _apply();
+        }),
+
+        _divider(),
+
+        // ── Pitch & tempo ──────────────────────────────────────────────
+        _sectionHeader('Pitch & Tempo'),
+        SwitchListTile.adaptive(
+          value: _rubberbandEnabled,
+          onChanged: (v) {
+            setState(() => _rubberbandEnabled = v);
+            _apply();
+          },
+          title:
+              Text('Enable pitch/tempo shift', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'High-quality rubberband engine',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_rubberbandEnabled) ...[
+          _sliderRow(
+            'Pitch',
+            _pitch,
+            0.5,
+            2.0,
+            30,
+            (v) => setState(() => _pitch = v),
+            _apply,
+            suffix: '×',
+            precision: 2,
+          ),
+          _sliderRow(
+            'Tempo',
+            _tempo,
+            0.5,
+            2.0,
+            30,
+            (v) => setState(() => _tempo = v),
+            _apply,
+            suffix: '×',
+            precision: 2,
           ),
         ],
-      ),
+
+        _divider(),
+
+        // ── Spatial ────────────────────────────────────────────────────
+        _sectionHeader('Spatial'),
+        SwitchListTile.adaptive(
+          value: _crossfeed,
+          onChanged: (v) {
+            setState(() => _crossfeed = v);
+            _apply();
+          },
+          title: Text('Crossfeed', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'Headphone crossfeed for natural imaging',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_crossfeed)
+          _sliderRow(
+            'Strength',
+            _crossfeedStrength,
+            0.0,
+            1.0,
+            20,
+            (v) => setState(() => _crossfeedStrength = v),
+            _apply,
+            precision: 2,
+          ),
+        SwitchListTile.adaptive(
+          value: _stereoWiden,
+          onChanged: (v) {
+            setState(() => _stereoWiden = v);
+            _apply();
+          },
+          title: Text('Stereo widening', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'Expands stereo image',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_stereoWiden)
+          _sliderRow(
+            'Delay',
+            _stereoWidenDelay,
+            1.0,
+            100.0,
+            99,
+            (v) => setState(() => _stereoWidenDelay = v),
+            _apply,
+            suffix: 'ms',
+            precision: 0,
+          ),
+
+        _divider(),
+
+        // ── Creative ───────────────────────────────────────────────────
+        _sectionHeader('Creative'),
+        SwitchListTile.adaptive(
+          value: _exciter,
+          onChanged: (v) {
+            setState(() => _exciter = v);
+            _apply();
+          },
+          title: Text('Harmonic exciter', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'Adds harmonic overtones',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_exciter)
+          _sliderRow(
+            'Amount',
+            _exciterAmount,
+            0.0,
+            10.0,
+            20,
+            (v) => setState(() => _exciterAmount = v),
+            _apply,
+            precision: 1,
+          ),
+        SwitchListTile.adaptive(
+          value: _crystalizer,
+          onChanged: (v) {
+            setState(() => _crystalizer = v);
+            _apply();
+          },
+          title: Text('Crystalizer', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'Audio sharpener / brightener',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_crystalizer)
+          _sliderRow(
+            'Intensity',
+            _crystalizerIntensity,
+            -10.0,
+            10.0,
+            40,
+            (v) => setState(() => _crystalizerIntensity = v),
+            _apply,
+            precision: 1,
+          ),
+        SwitchListTile.adaptive(
+          value: _virtualBass,
+          onChanged: (v) {
+            setState(() => _virtualBass = v);
+            _apply();
+          },
+          title: Text('Virtual bass', style: AfTypography.bodyMedium),
+          subtitle: Text(
+            'Psychoacoustic bass enhancement',
+            style: AfTypography.bodySmall
+                .copyWith(color: AfColors.textTertiary),
+          ),
+          activeThumbColor: AfColors.indigo500,
+          contentPadding: EdgeInsets.zero,
+        ),
+        if (_virtualBass)
+          _sliderRow(
+            'Cutoff',
+            _virtualBassCutoff,
+            100.0,
+            500.0,
+            40,
+            (v) => setState(() => _virtualBassCutoff = v),
+            _apply,
+            suffix: 'Hz',
+            precision: 0,
+          ),
+
+        const SizedBox(height: AfSpacing.s24),
+      ],
     );
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  Widget _sectionHeader(String title) => Padding(
+        padding: const EdgeInsets.only(top: AfSpacing.s8, bottom: AfSpacing.s4),
+        child: Text(title,
+            style: AfTypography.label
+                .copyWith(color: AfColors.textSecondary)),
+      );
+
+  Widget _divider() => const Padding(
+        padding: EdgeInsets.symmetric(vertical: AfSpacing.s8),
+        child: Divider(height: 1, color: AfColors.surfaceHigh),
+      );
+
+  Widget _toggleTile(
+    String title,
+    String subtitle,
+    bool value,
+    ValueChanged<bool> onChanged,
+  ) {
+    return SwitchListTile.adaptive(
+      value: value,
+      onChanged: onChanged,
+      title: Text(title, style: AfTypography.bodyMedium),
+      subtitle: Text(
+        subtitle,
+        style:
+            AfTypography.bodySmall.copyWith(color: AfColors.textTertiary),
+      ),
+      activeThumbColor: AfColors.indigo500,
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  Widget _sliderRow(
+    String label,
+    double value,
+    double min,
+    double max,
+    int divisions,
+    ValueChanged<double> onChanged,
+    VoidCallback onChangeEnd, {
+    String? suffix,
+    int precision = 0,
+  }) {
+    final display = value >= 0 && suffix == 'dB'
+        ? '+${value.toStringAsFixed(precision)}'
+        : value.toStringAsFixed(precision);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Text(label, style: AfTypography.bodyMedium),
+            const Spacer(),
+            Text(
+              suffix != null ? '$display $suffix' : display,
+              style:
+                  AfTypography.mono.copyWith(color: AfColors.textTertiary),
+            ),
+          ],
+        ),
+        Slider(
+          value: value,
+          min: min,
+          max: max,
+          divisions: divisions,
+          activeColor: AfColors.indigo400,
+          onChanged: onChanged,
+          onChangeEnd: (_) => onChangeEnd(),
+        ),
+      ],
+    );
+  }
+
+  /// Only include bands that differ from the flat default (1.0).
+  Map<String, double> _buildEqParams() {
+    final params = <String, double>{};
+    for (final entry in _eqBands.entries) {
+      if (entry.value != 1.0) params[entry.key] = entry.value;
+    }
+    return params;
+  }
+
+  List<Widget> _buildEqBands() {
+    return _kEqBands.entries.map((entry) {
+      final bandKey = entry.key;
+      final freq = entry.value;
+      final gain = _eqBands[bandKey] ?? 1.0;
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 58,
+              child: Text(
+                freq,
+                style: AfTypography.mono.copyWith(
+                  fontSize: 11,
+                  color: AfColors.textTertiary,
+                ),
+              ),
+            ),
+            Expanded(
+              child: SliderTheme(
+                data: SliderTheme.of(context).copyWith(
+                  trackHeight: 2,
+                  thumbShape:
+                      const RoundSliderThumbShape(enabledThumbRadius: 6),
+                  overlayShape:
+                      const RoundSliderOverlayShape(overlayRadius: 12),
+                ),
+                child: Slider(
+                  value: gain.clamp(0.0, 4.0),
+                  min: 0,
+                  max: 4,
+                  divisions: 40,
+                  activeColor: AfColors.indigo400,
+                  onChanged: (v) {
+                    setState(() => _eqBands[bandKey] = v);
+                  },
+                  onChangeEnd: (_) => _apply(),
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 36,
+              child: Text(
+                gain.toStringAsFixed(1),
+                textAlign: TextAlign.right,
+                style: AfTypography.mono.copyWith(
+                  fontSize: 11,
+                  color: AfColors.textTertiary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }).toList();
   }
 }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mpv_audio_kit/mpv_audio_kit.dart' show AudioParams, Cache, Format, ReplayGain;
+import 'package:mpv_audio_kit/mpv_audio_kit.dart'
+    show AudioParams, Cache, Format, Gapless, ReplayGain, ReplayGainSettings;
 
 import '../../core/audio/player_settings_store.dart';
 import '../../design_tokens/tokens.dart';
@@ -227,6 +228,50 @@ class SettingsScreen extends ConsumerWidget {
               shape: const RoundedRectangleBorder(
                   borderRadius: AfRadii.borderMd),
               onTap: () => _showReplayGainDialog(context, ref),
+            ),
+            const SizedBox(height: AfSpacing.s8),
+            ListTile(
+              leading: const Icon(Icons.skip_next_rounded),
+              title: const Text('Gapless playback'),
+              subtitle: Text(
+                'Seamless transitions between tracks',
+                style: AfTypography.bodySmall.copyWith(
+                  color: AfColors.textTertiary,
+                ),
+              ),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              tileColor: AfColors.surfaceBase,
+              shape: const RoundedRectangleBorder(
+                  borderRadius: AfRadii.borderMd),
+              onTap: () => _showGaplessDialog(context, ref),
+            ),
+            const SizedBox(height: AfSpacing.s8),
+            StreamBuilder<bool>(
+              stream: Stream<bool>.multi((controller) {
+                controller.add(svc.prefetchPlaylist);
+              }),
+              initialData: svc.prefetchPlaylist,
+              builder: (context, snap) {
+                final enabled = snap.data ?? false;
+                return SwitchListTile.adaptive(
+                  value: enabled,
+                  onChanged: (v) {
+                    unawaited(svc.setPrefetchPlaylist(v));
+                    unawaited(PlayerSettingsStore.savePrefetchPlaylist(v));
+                  },
+                  title: const Text('Prefetch next track'),
+                  subtitle: Text(
+                    'Pre-load next playlist entry in background',
+                    style: AfTypography.bodySmall.copyWith(
+                      color: AfColors.textTertiary,
+                    ),
+                  ),
+                  activeThumbColor: AfColors.indigo500,
+                  tileColor: AfColors.surfaceBase,
+                  shape: const RoundedRectangleBorder(
+                      borderRadius: AfRadii.borderMd),
+                );
+              },
             ),
             const SizedBox(height: AfSpacing.s24),
             _SectionLabel('About'),
@@ -555,14 +600,14 @@ class _OptionTile extends StatelessWidget {
   }
 }
 
-void _showReplayGainDialog(BuildContext context, WidgetRef ref) {
+void _showGaplessDialog(BuildContext context, WidgetRef ref) {
   final svc = ref.read(playerServiceProvider);
-  final current = svc.replayGain.mode;
+  final current = svc.gaplessMode;
 
-  const options = <(ReplayGain, String, String)>[
-    (ReplayGain.no, 'Off', 'No volume normalization'),
-    (ReplayGain.track, 'Track', 'Normalize each track independently'),
-    (ReplayGain.album, 'Album', 'Normalize per album (preserves dynamics)'),
+  const options = <(Gapless, String, String)>[
+    (Gapless.yes, 'Full', 'Re-uses decoder for seamless transitions'),
+    (Gapless.weak, 'Weak', 'Gapless only on compatible formats (default)'),
+    (Gapless.no, 'Off', 'Close and re-open audio output between tracks'),
   ];
 
   showDialog<void>(
@@ -579,14 +624,15 @@ void _showReplayGainDialog(BuildContext context, WidgetRef ref) {
             Padding(
               padding: const EdgeInsets.symmetric(
                   horizontal: AfSpacing.gutterGenerous),
-              child: Text('ReplayGain', style: AfTypography.titleSmall),
+              child:
+                  Text('Gapless playback', style: AfTypography.titleSmall),
             ),
             const SizedBox(height: AfSpacing.s4),
             Padding(
               padding: const EdgeInsets.symmetric(
                   horizontal: AfSpacing.gutterGenerous),
               child: Text(
-                'Normalize volume so all tracks play at a similar loudness.',
+                'Controls how the player handles track transitions.',
                 style: AfTypography.bodySmall
                     .copyWith(color: AfColors.textTertiary),
               ),
@@ -598,10 +644,8 @@ void _showReplayGainDialog(BuildContext context, WidgetRef ref) {
                 subtitle: subtitle,
                 isActive: mode == current,
                 onTap: () {
-                  unawaited(svc.setReplayGain(
-                    svc.replayGain.copyWith(mode: mode),
-                  ));
-                  unawaited(PlayerSettingsStore.saveReplayGain(mode));
+                  unawaited(svc.setGapless(mode));
+                  unawaited(PlayerSettingsStore.saveGapless(mode));
                   Navigator.of(dialogCtx).pop();
                 },
               ),
@@ -610,4 +654,190 @@ void _showReplayGainDialog(BuildContext context, WidgetRef ref) {
       ),
     ),
   );
+}
+
+void _showReplayGainDialog(BuildContext context, WidgetRef ref) {
+  showDialog<void>(
+    context: context,
+    builder: (dialogCtx) => Dialog(
+      backgroundColor: AfColors.surfaceBase,
+      shape: RoundedRectangleBorder(borderRadius: AfRadii.borderLg),
+      child: _ReplayGainDialogContent(),
+    ),
+  );
+}
+
+class _ReplayGainDialogContent extends ConsumerStatefulWidget {
+  @override
+  ConsumerState<_ReplayGainDialogContent> createState() =>
+      _ReplayGainDialogContentState();
+}
+
+class _ReplayGainDialogContentState
+    extends ConsumerState<_ReplayGainDialogContent> {
+  late ReplayGain _mode;
+  late double _preamp;
+  late double _fallback;
+  late bool _clip;
+
+  @override
+  void initState() {
+    super.initState();
+    final rg = ref.read(playerServiceProvider).replayGain;
+    _mode = rg.mode;
+    _preamp = rg.preamp.clamp(-15.0, 15.0);
+    _fallback = rg.fallback.clamp(-15.0, 0.0);
+    _clip = rg.clip;
+  }
+
+  void _apply() {
+    final svc = ref.read(playerServiceProvider);
+    final settings = ReplayGainSettings(
+      mode: _mode,
+      preamp: _preamp,
+      fallback: _fallback,
+      clip: _clip,
+    );
+    unawaited(svc.setReplayGain(settings));
+    unawaited(PlayerSettingsStore.saveReplayGainFull(settings));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const options = <(ReplayGain, String, String)>[
+      (ReplayGain.no, 'Off', 'No volume normalization'),
+      (ReplayGain.track, 'Track', 'Normalize each track independently'),
+      (ReplayGain.album, 'Album', 'Normalize per album (preserves dynamics)'),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AfSpacing.s16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+                horizontal: AfSpacing.gutterGenerous),
+            child: Text('ReplayGain', style: AfTypography.titleSmall),
+          ),
+          const SizedBox(height: AfSpacing.s4),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+                horizontal: AfSpacing.gutterGenerous),
+            child: Text(
+              'Normalize volume so all tracks play at a similar loudness.',
+              style: AfTypography.bodySmall
+                  .copyWith(color: AfColors.textTertiary),
+            ),
+          ),
+          const SizedBox(height: AfSpacing.s8),
+          for (final (mode, label, subtitle) in options)
+            _OptionTile(
+              label: label,
+              subtitle: subtitle,
+              isActive: mode == _mode,
+              onTap: () {
+                setState(() => _mode = mode);
+                _apply();
+              },
+            ),
+          if (_mode != ReplayGain.no) ...[
+            const SizedBox(height: AfSpacing.s8),
+            const Divider(height: 1, color: AfColors.surfaceHigh),
+            const SizedBox(height: AfSpacing.s8),
+            // Preamp slider.
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: AfSpacing.gutterGenerous),
+              child: Row(
+                children: [
+                  Text('Pre-amp', style: AfTypography.bodyMedium),
+                  const Spacer(),
+                  Text(
+                    '${_preamp >= 0 ? "+" : ""}${_preamp.toStringAsFixed(1)} dB',
+                    style: AfTypography.mono
+                        .copyWith(color: AfColors.textTertiary),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: AfSpacing.gutterGenerous),
+              child: Slider(
+                value: _preamp,
+                min: -15,
+                max: 15,
+                divisions: 30,
+                activeColor: AfColors.indigo400,
+                onChanged: (v) => setState(() => _preamp = v),
+                onChangeEnd: (_) => _apply(),
+              ),
+            ),
+            // Fallback gain slider.
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: AfSpacing.gutterGenerous),
+              child: Row(
+                children: [
+                  Text('Fallback gain', style: AfTypography.bodyMedium),
+                  const Spacer(),
+                  Text(
+                    '${_fallback.toStringAsFixed(1)} dB',
+                    style: AfTypography.mono
+                        .copyWith(color: AfColors.textTertiary),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: AfSpacing.gutterGenerous),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Slider(
+                    value: _fallback,
+                    min: -15,
+                    max: 0,
+                    divisions: 30,
+                    activeColor: AfColors.indigo400,
+                    onChanged: (v) => setState(() => _fallback = v),
+                    onChangeEnd: (_) => _apply(),
+                  ),
+                  Text(
+                    'Applied to files without ReplayGain tags',
+                    style: AfTypography.caption
+                        .copyWith(color: AfColors.textTertiary),
+                  ),
+                ],
+              ),
+            ),
+            // Clip prevention toggle.
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: AfSpacing.gutterGenerous),
+              child: SwitchListTile.adaptive(
+                value: !_clip,
+                onChanged: (v) {
+                  setState(() => _clip = !v);
+                  _apply();
+                },
+                title: Text('Prevent clipping',
+                    style: AfTypography.bodyMedium),
+                subtitle: Text(
+                  'Peak-limit output to avoid distortion',
+                  style: AfTypography.bodySmall
+                      .copyWith(color: AfColors.textTertiary),
+                ),
+                activeThumbColor: AfColors.indigo500,
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
 }

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -260,9 +260,13 @@ final playbackSpeedProvider = StreamProvider.autoDispose<double>((ref) {
 });
 
 /// Real-time FFT spectrum from mpv_audio_kit — 64 log-spaced bands in
-/// [0, 1] at ~30 fps, post-DSP (after EQ, volume, compressor).
-/// No RECORD_AUDIO permission needed. Lazy: pipeline starts on first
-/// listener, stops on last cancel. Drives [BeatPulseArtwork].
+/// [0, 1] at ~30 fps. No RECORD_AUDIO permission needed. Lazy: pipeline
+/// starts on first listener, stops on last cancel. Drives [BeatPulseArtwork].
+///
+/// Note: The spectrum is captured post-DSP (`pcm-tap-frame`).
+/// `mpv_audio_kit` 0.1.3 does not expose a pre-DSP tap point.
+/// A future library update may add a bypass option; until then the
+/// visualizer reflects processed audio.
 final fftSpectrumProvider = StreamProvider.autoDispose<FftFrame>((ref) {
   final svc = ref.watch(playerServiceProvider);
   return svc.spectrumStream;


### PR DESCRIPTION
## Summary

Implements the audio DSP/effects feature set from section 5 of the spec. The EQ dialog is expanded from a simple bass/treble/loudnorm/compressor panel into a comprehensive scrollable bottom sheet with 13 effect types, all wired through `mpv_audio_kit`'s `AudioEffects` bundle. ReplayGain, Gapless, and Prefetch settings are also expanded and fully persisted.

**DSP dialog (now_playing_screen.dart):**
- 18-band Superequalizer (ISO graphic EQ) with per-band sliders (0..4 linear gain, 1.0 = flat)
- Rubberband pitch & tempo shifting (0.5x–2.0x)
- Crossfeed (headphone crossfeed with strength control)
- Stereo widening (adjustable delay)
- Harmonic exciter (adjustable amount)
- Crystalizer (audio sharpener/brightener with intensity)
- Virtual bass (psychoacoustic enhancement with cutoff)
- Noise gate toggle
- De-esser toggle
- Reset all button clears every effect
- Dialog refactored to `DraggableScrollableSheet` bottom sheet

**ReplayGain (settings_screen.dart):**
- Preamp slider (±15 dB)
- Fallback gain slider (-15..0 dB) for files without RG tags
- Clip prevention toggle

**Gapless & Prefetch (settings_screen.dart):**
- Gapless mode picker (Full / Weak / Off)
- Prefetch next track toggle

**Persistence (player_settings_store.dart):**
- Full audio effects bundle serialized to JSON via `shared_preferences`
- ReplayGain preamp/fallback/clip persisted
- Prefetch playlist persisted
- All restored on app startup via `applyPersisted()`

**Visualizer DSP bypass:**
- `mpv_audio_kit` 0.1.3 spectrum is post-DSP (`pcm-tap-frame`). No pre-DSP tap available. Documented as known limitation.

## Review & Testing Checklist for Human
- [ ] **Build and launch** — verify the app compiles and starts on Android
- [ ] **Open the EQ/DSP dialog** from now-playing screen and verify all 13 effect sections render with sliders/toggles
- [ ] **Toggle effects** — enable bass boost, EQ bands, pitch shift, crossfeed etc. and verify audio changes
- [ ] **Reset all** — tap reset and verify all controls return to defaults
- [ ] **Kill and restart the app** — verify that enabled effects are restored on cold start
- [ ] **ReplayGain settings** — open Settings → ReplayGain, adjust preamp/fallback, toggle clip prevention
- [ ] **Gapless picker** — open Settings → Gapless, pick Full/Weak/Off
- [ ] **Prefetch toggle** — enable prefetch in Settings

### Notes
- The visualizer still reflects post-DSP audio because `mpv_audio_kit` 0.1.3 only exposes a post-DSP FFT tap. A pre-DSP bypass would require a library update.
- Echo/delay effect is not included — `AechoSettings` requires string-typed parameters that don't map to simple sliders. Can be added in a follow-up.
- The superequalizer uses linear gain (0..4, 1.0 = flat) matching `mpv_audio_kit`'s API.

Session: https://app.devin.ai/sessions/f7d0c3061d794d97ab807510d360a837