### PR TITLE
Code review fixes + progress bar freeze bug fix

### DIFF
--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -401,8 +401,8 @@ class AfPlayerService extends BaseAudioHandler
         maxDb: 35.0,
         emitInterval: Duration(milliseconds: 8),
       ));
-    } catch (_) {
-      // Player not ready yet — spectrum will use defaults.
+    } catch (e) {
+      afLog('audio', 'configureSpectrum failed', error: e);
     }
   }
 
@@ -548,8 +548,8 @@ class AfPlayerService extends BaseAudioHandler
           .timeout(const Duration(seconds: 2));
 
       _syncTrackQueueFromMpv(newPlaylist.items, newPlaylist.index);
-    } catch (_) {
-      // Timeout — try reading state directly as fallback.
+    } catch (e) {
+      afLog('audio', 'shuffle playlist stream timeout, using state fallback', error: e);
       final mpvItems = _player.state.playlist.items;
       final newIdx = _player.state.playlist.index;
       _syncTrackQueueFromMpv(mpvItems, newIdx);
@@ -957,8 +957,8 @@ class AfPlayerService extends BaseAudioHandler
       await File(path).writeAsBytes(raw.bytes);
       _coverPath = path;
       _updateMediaItem();
-    } catch (_) {
-      // Disk full / sandbox — fall back to network URL in _updateMediaItem.
+    } catch (e) {
+      afLog('audio', 'cover art persist failed', error: e);
     }
   }
 }

--- a/lib/core/audio/player_service.dart
+++ b/lib/core/audio/player_service.dart
@@ -600,16 +600,24 @@ class AfPlayerService extends BaseAudioHandler
     }
   }
 
-  /// Extracts the Jellyfin track ID from a stream URL.
-  /// URL format: `.../Audio/{trackId}/stream?...`
+  /// Extracts the track ID from a stream URL.
+  ///
+  /// Supports both URL formats:
+  ///   Jellyfin:  `.../Audio/{trackId}/stream?...`
+  ///   Subsonic:  `.../rest/stream.view?id={trackId}&...`
   static String? _extractTrackId(String uri) {
-    final segments = Uri.tryParse(uri)?.pathSegments;
-    if (segments == null) return null;
+    final parsed = Uri.tryParse(uri);
+    if (parsed == null) return null;
+    // Jellyfin: /Audio/{id}/stream
+    final segments = parsed.pathSegments;
     for (var i = 0; i < segments.length - 1; i++) {
       if (segments[i].toLowerCase() == 'audio') {
         return segments[i + 1];
       }
     }
+    // Subsonic: /rest/stream.view?id={id}
+    final queryId = parsed.queryParameters['id'];
+    if (queryId != null && queryId.isNotEmpty) return queryId;
     return null;
   }
 

--- a/lib/core/audio/spectral_extractor.dart
+++ b/lib/core/audio/spectral_extractor.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image/cached_network_image.dart'
 import 'package:palette_generator_master/palette_generator_master.dart';
 
 import '../../design_tokens/colors.dart';
+import '../../utils/log.dart';
 import '../../utils/oklch.dart';
 
 /// Extracts the spectral accent triple from an artwork URL.
@@ -77,9 +78,8 @@ class SpectralExtractor {
         _cache.remove(_cache.keys.first);
       }
       return result;
-    } catch (_) {
-      // Image decode failure, malformed image, or palette extraction crash.
-      // Return fallback so the UI never crashes on bad artwork.
+    } catch (e) {
+      afLog('spectral', 'palette extraction failed for $imageUrl', error: e);
       return Spectral.fallback;
     }
   }

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -28,6 +28,8 @@ const _kAetherfinUserAgent = 'Aetherfin/$_kAetherfinVersion (Android)';
 /// Hand-rolled per design spec §11.1 — community Dart SDKs are stale and
 /// the surface we need is small.
 class JellyfinClient implements MusicBackend {
+  static final _genreSplitRe = RegExp(r'[,;]');
+
   final JellyfinServer server;
   final String? accessToken;
   final String? userId;
@@ -623,7 +625,7 @@ class JellyfinClient implements MusicBackend {
     for (final m in items) {
       final raw = (m['Name'] as String?) ?? '';
       if (raw.isEmpty) continue;
-      for (final part in raw.split(RegExp(r'[,;]'))) {
+      for (final part in raw.split(_genreSplitRe)) {
         final token = part.trim();
         if (token.isEmpty) continue;
         final key = token.toLowerCase();

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -362,11 +362,7 @@ class JellyfinClient implements MusicBackend {
   ///
   /// Uses `/Audio/{id}/stream?Static=true` — the direct-stream endpoint
   /// which serves the original file byte-for-byte (mp3 / flac / m4a /
-  /// ogg / wav / opus). just_audio's ExoPlayer plays these natively.
-  ///
-  /// Build a streaming URL for a given track ID.
-  ///
-  /// Uses `/Audio/{id}/stream?Static=true` — the direct-stream endpoint.
+  /// ogg / wav / opus).
   ///
   /// The access token is embedded as `api_key=<token>` in the URL because
   /// libmpv/FFmpeg's HTTP client (lavf) rejects the `Authorization: MediaBrowser …`

--- a/lib/core/jellyfin/client.dart
+++ b/lib/core/jellyfin/client.dart
@@ -3,6 +3,7 @@ import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 
 import '../../utils/log.dart';
+import '../../utils/url.dart';
 import '../backend/music_backend.dart';
 import 'models/items.dart';
 import 'models/library.dart';
@@ -391,9 +392,7 @@ class JellyfinClient implements MusicBackend {
       // ignore: use_null_aware_elements — map is Map<String,String>, value is String?
       if (deviceProfileId != null) 'DeviceProfileId': deviceProfileId,
     };
-    final base = server.baseUrl.endsWith('/')
-        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
-        : server.baseUrl;
+    final base = stripTrailingSlash(server.baseUrl);
     return Uri.parse(base)
         .replace(
           path: '${Uri.parse(base).path}/Audio/$trackId/stream',
@@ -1254,9 +1253,7 @@ class JellyfinClient implements MusicBackend {
       'quality': '$quality',
       'tag': tag,
     };
-    final base = server.baseUrl.endsWith('/')
-        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
-        : server.baseUrl;
+    final base = stripTrailingSlash(server.baseUrl);
     return Uri.parse(base)
         .replace(
           path: '${Uri.parse(base).path}/Items/$itemId/Images/$imageType',

--- a/lib/core/jellyfin/models/server.dart
+++ b/lib/core/jellyfin/models/server.dart
@@ -69,6 +69,11 @@ class JellyfinAuth {
   final JellyfinServer server;
   final String userId;
   final String userName;
+
+  /// For Jellyfin: the API access token from `/Users/AuthenticateByName`.
+  /// For Subsonic/Navidrome: the user's plaintext password (stored in
+  /// encrypted secure storage), needed to compute `md5(password + salt)`
+  /// per-request auth tokens.
   final String accessToken;
 
   /// Identifies the server backend. Defaults to [ServerType.jellyfin]

--- a/lib/core/subsonic/client.dart
+++ b/lib/core/subsonic/client.dart
@@ -476,10 +476,10 @@ class SubsonicClient implements MusicBackend {
   @override
   Future<void> movePlaylistItem(
       String playlistId, String itemId, int newIndex) async {
-    // Subsonic doesn't support direct move. We'd need to rebuild the
-    // playlist. For now, this is a no-op with a log warning.
-    afLog('subsonic',
-        'movePlaylistItem not natively supported by Subsonic API');
+    // Subsonic API has no playlist-reorder endpoint. Throwing lets the UI
+    // catch this and show a toast instead of silently discarding the move.
+    throw UnsupportedError(
+        'Subsonic API does not support playlist item reordering');
   }
 
   @override

--- a/lib/core/subsonic/client.dart
+++ b/lib/core/subsonic/client.dart
@@ -7,6 +7,7 @@ import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 
 import '../../utils/log.dart';
+import '../../utils/url.dart';
 import '../backend/music_backend.dart';
 import '../jellyfin/models/items.dart';
 import '../jellyfin/models/library.dart';
@@ -564,9 +565,7 @@ class SubsonicClient implements MusicBackend {
       'id': trackId,
       if (maxBitrateKbps != null) 'maxBitRate': '$maxBitrateKbps',
     };
-    final base = server.baseUrl.endsWith('/')
-        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
-        : server.baseUrl;
+    final base = stripTrailingSlash(server.baseUrl);
     return Uri.parse(base)
         .replace(
           path: '${Uri.parse(base).path}/rest/stream.view',
@@ -583,9 +582,7 @@ class SubsonicClient implements MusicBackend {
       'id': coverArtId,
       'size': '$size',
     };
-    final base = server.baseUrl.endsWith('/')
-        ? server.baseUrl.substring(0, server.baseUrl.length - 1)
-        : server.baseUrl;
+    final base = stripTrailingSlash(server.baseUrl);
     return Uri.parse(base)
         .replace(
           path: '${Uri.parse(base).path}/rest/getCoverArt.view',

--- a/lib/core/subsonic/client.dart
+++ b/lib/core/subsonic/client.dart
@@ -188,7 +188,9 @@ class SubsonicClient implements MusicBackend {
       try {
         final detail = await album(a.id);
         if (detail != null) tracks.addAll(detail.tracks);
-      } catch (_) {}
+      } catch (e) {
+        afLog('subsonic', 'recentlyPlayed album fetch failed id=${a.id}', error: e);
+      }
     }
     return tracks.take(limit).toList(growable: false);
   }
@@ -348,7 +350,8 @@ class SubsonicClient implements MusicBackend {
               ?.cast<Map<String, dynamic>>() ??
           const [];
       return songs.map(_parseTrack).toList(growable: false);
-    } catch (_) {
+    } catch (e) {
+      afLog('subsonic', 'getTopSongs failed, falling back to search', error: e);
       // getTopSongs may not be supported; fall back to search
       final root = await _get('search3', {
         'query': artistObj.name,
@@ -510,7 +513,8 @@ class SubsonicClient implements MusicBackend {
               ?.cast<Map<String, dynamic>>() ??
           const [];
       return songs.map(_parseTrack).toList(growable: false);
-    } catch (_) {
+    } catch (e) {
+      afLog('subsonic', 'getSimilarSongs2 failed', error: e);
       // getSimilarSongs2 may not be supported; return empty
       return const [];
     }
@@ -550,7 +554,8 @@ class SubsonicClient implements MusicBackend {
         }
       }
       return buf.toString();
-    } catch (_) {
+    } catch (e) {
+      afLog('subsonic', 'getLyricsBySongId failed', error: e);
       // Fall back to legacy getLyrics (requires artist + title)
       return null;
     }
@@ -600,8 +605,8 @@ class SubsonicClient implements MusicBackend {
         'id': trackId,
         'submission': false,
       });
-    } catch (_) {
-      // Best-effort; don't crash if scrobble isn't supported
+    } catch (e) {
+      afLog('subsonic', 'reportPlaybackStart scrobble failed', error: e);
     }
   }
 
@@ -621,8 +626,8 @@ class SubsonicClient implements MusicBackend {
         'id': trackId,
         'submission': true,
       });
-    } catch (_) {
-      // Best-effort
+    } catch (e) {
+      afLog('subsonic', 'reportPlaybackStop scrobble failed', error: e);
     }
   }
 

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -357,7 +357,8 @@ final spectralProvider =
     return await ref
         .watch(spectralExtractorProvider)
         .fromImageUrl(track!.imageUrl!, headers: headers);
-  } catch (_) {
+  } catch (e) {
+    afLog('spectral', 'spectral extraction failed', error: e);
     return Spectral.fallback;
   }
 });
@@ -448,8 +449,8 @@ final playlistTrackIdsProvider =
           ids.add(t.id);
         }
       }
-    } catch (_) {
-      // Skip playlists that fail to load.
+    } catch (e) {
+      afLog('data', 'playlist track fetch failed id=${pl.id}', error: e);
     }
   }
   return ids;

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show unawaited;
+import 'dart:async' show StreamController, Timer, unawaited;
 
 import 'package:flutter/widgets.dart' show WidgetsBinding;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -218,9 +218,42 @@ final playerQueueProvider = StreamProvider.autoDispose<List<AfTrack>>((ref) {
 /// Stream of position from the single player. Per non-negotiable §4.3,
 /// every UI consumer (ring, waveform, lyric scroll, time labels) listens
 /// to THIS stream — never a private timer.
+///
+/// mpv_audio_kit's ReactiveProperty deduplicates by == — when position
+/// resets to the same Duration (e.g. Duration.zero on track change or
+/// seek-to-start), the reactive stream suppresses the event. A 200 ms
+/// heartbeat polls the synchronous position to guarantee the UI always
+/// has fresh data even when the reactive stream is silent.
 final positionStreamProvider = StreamProvider.autoDispose<Duration>((ref) {
   final svc = ref.watch(playerServiceProvider);
-  return svc.positionStream;
+  final ctrl = StreamController<Duration>();
+  Duration lastEmitted = const Duration(microseconds: -1);
+
+  void emit(Duration pos) {
+    if (pos == lastEmitted) return;
+    lastEmitted = pos;
+    ctrl.add(pos);
+  }
+
+  // Seed with the current synchronous position so the first frame
+  // renders without waiting for the next stream tick.
+  emit(svc.position);
+
+  // Forward high-frequency reactive events.
+  final sub = svc.positionStream.listen((pos) => emit(pos));
+
+  // Heartbeat: catch dedup gaps at ~5 Hz.
+  final timer = Timer.periodic(const Duration(milliseconds: 200), (_) {
+    emit(svc.position);
+  });
+
+  ref.onDispose(() {
+    timer.cancel();
+    sub.cancel();
+    ctrl.close();
+  });
+
+  return ctrl.stream;
 });
 
 final playingStreamProvider = StreamProvider.autoDispose<bool>((ref) {

--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show unawaited;
 
+import 'package:flutter/widgets.dart' show WidgetsBinding;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mpv_audio_kit/mpv_audio_kit.dart' show Loop, FftFrame;
 
@@ -747,9 +748,14 @@ final lyricsProvider =
 final showNavLabelsProvider = StateProvider<bool>((ref) => false);
 
 final reducedMotionProvider = Provider.autoDispose<bool>((ref) {
-  // Re-evaluated whenever MediaQuery changes — UIs read this via
-  // MediaQuery.disableAnimations OR via this provider in non-widget code.
-  return false;
+  // Read the platform accessibility setting so animations can be toned down
+  // for users who prefer reduced motion. WidgetsBinding exposes this without
+  // needing a BuildContext, making it safe to use in non-widget code.
+  try {
+    return WidgetsBinding.instance.accessibilityFeatures.reduceMotion;
+  } catch (_) {
+    return false;
+  }
 });
 
 /// ─────────────────────────────────────────────────────────────────────────

--- a/lib/utils/url.dart
+++ b/lib/utils/url.dart
@@ -1,0 +1,7 @@
+/// Strip the trailing slash from [url] if present.
+///
+/// Used by both [JellyfinClient] and [SubsonicClient] when building
+/// stream / image URLs via `Uri.replace` — a trailing slash would
+/// produce a double-slash in the path segment.
+String stripTrailingSlash(String url) =>
+    url.endsWith('/') ? url.substring(0, url.length - 1) : url;


### PR DESCRIPTION
## Summary

9 focused commits from a comprehensive code review plus a bug fix for the progress bar / mini-player ring freezing on track change or seek-to-start.

### Code review fixes (8 commits)

1. `c561d98` — `_extractTrackId` now supports Subsonic URLs. Previously shuffle sync silently dropped all tracks on Navidrome.
2. `026949d` — `SubsonicClient.movePlaylistItem` now throws `UnsupportedError` instead of silently no-oping.
3. `ab4c8cb` — Removed duplicated doc comment on `JellyfinClient.trackStreamUrl`.
4. `e08f456` — Extracted `stripTrailingSlash()` into `lib/utils/url.dart` to replace 4 duplicated inline trims.
5. `c1ec763` — Pre-compiled the genre split regex as a static field on `JellyfinClient`.
6. `5db855c` — Replaced 11 bare `catch (_) {}` blocks with `catch (e) { afLog() }` across 4 files.
7. `55403dc` — `reducedMotionProvider` now reads system accessibility preference instead of hardcoded `false`.
8. `de1fbc5` — Documented the dual-use of `JellyfinAuth.accessToken`.

### Bug fix (1 commit)

9. `2b55eed` — **Fix progress bar / mini-player ring freeze on track change or seek-to-start.**

   **Root cause:** mpv_audio_kit's ReactiveProperty deduplicates by ==. When position resets to Duration.zero, the reactive stream suppresses the event if the value was already zero.

   **Fix:** Rewired positionStreamProvider to (a) seed with current synchronous position, and (b) add a 200ms heartbeat that polls player.state.position to catch dedup gaps. Fixes both now-playing scrubber and mini-player ring.

## Review and Testing Checklist for Human

- [ ] Play through a track change — verify progress bar and mini-player ring keep moving
- [ ] Seek to 0:00 — tap the very start of the scrubber, progress should resume immediately
- [ ] Shuffle on Navidrome — toggle shuffle and verify queue stays correct
- [ ] Drag-to-reorder a playlist on Navidrome — should now surface an error instead of silently failing
- [ ] Accessibility: reduced motion — enable Remove animations in Android settings and verify the app respects it

### Notes

- All changes are backward-compatible. No new dependencies, no API surface changes.
- The 200ms heartbeat adds negligible overhead and only emits when the value changed.
- The stripTrailingSlash utility is shared by both clients to avoid double-slashes in stream/image URLs.