### PR TITLE
fix(library): surface backend errors on every section (was infinite spinner)

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -6,7 +6,7 @@ import '../../core/audio/play_actions.dart';
 import '../../core/battery_opt.dart';
 import '../../design_tokens/tokens.dart';
 import '../../state/providers.dart';
-import '../../utils/display_error.dart';
+import '../../widgets/async_error_view.dart';
 import '../../widgets/hero_album_card.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/tile.dart';
@@ -106,10 +106,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       },
                     ),
               loading: () => const SizedBox(height: 168),
-              error: (e, _) => _RailError(
+              error: (e, _) => AsyncErrorView.compact(
                 label: 'Couldn\u2019t load recent albums',
                 error: e,
-                reservedHeight: 168,
+                height: 168,
                 onRetry: () => ref.invalidate(
                   isLocal ? localAlbumsProvider : recentlyAddedAlbumsProvider,
                 ),
@@ -154,10 +154,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 },
               ),
               loading: () => const SizedBox(height: 80),
-              error: (e, _) => _RailError(
+              error: (e, _) => AsyncErrorView.compact(
                 label: 'Couldn\u2019t load recently played',
                 error: e,
-                reservedHeight: 80,
+                height: 80,
                 onRetry: () => ref.invalidate(
                   isLocal ? localTracksProvider : recentlyPlayedTracksProvider,
                 ),
@@ -182,10 +182,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           SliverToBoxAdapter(
             child: artistsAsync.when(
               loading: () => const SizedBox(height: 172),
-              error: (e, _) => _RailError(
+              error: (e, _) => AsyncErrorView.compact(
                 label: 'Couldn\u2019t load artists',
                 error: e,
-                reservedHeight: 172,
+                height: 172,
                 onRetry: () => ref.invalidate(
                   isLocal ? localArtistsProvider : allArtistsProvider,
                 ),
@@ -251,10 +251,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   },
                 ),
                 loading: () => const SizedBox.shrink(),
-                error: (e, _) => _RailError(
+                error: (e, _) => AsyncErrorView.compact(
                   label: 'Couldn\u2019t load genres',
                   error: e,
-                  reservedHeight: 96,
+                  height: 96,
                   onRetry: () => ref.invalidate(
                     isLocal ? localGenresProvider : allGenresProvider,
                   ),
@@ -280,77 +280,4 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 }
 
-/// Inline error card for a single Home rail.
-///
-/// Before this widget, every rail on Home used `maybeWhen(data:, orElse:)`
-/// which collapsed loading **and** error into a fixed-height blank space.
-/// When the server was unreachable, auth expired, or the backend returned
-/// a 5xx, the user saw an empty page and had no idea anything had failed.
-///
-/// Renders inside the reserved rail height (matches the loading skeleton
-/// size) so layout doesn't jump when an error surfaces. Uses
-/// `displayError` to redact auth query params from any DioException
-/// before showing the message to the user.
-class _RailError extends StatelessWidget {
-  final String label;
-  final Object error;
-  final double reservedHeight;
-  final VoidCallback onRetry;
 
-  const _RailError({
-    required this.label,
-    required this.error,
-    required this.reservedHeight,
-    required this.onRetry,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: reservedHeight,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AfSpacing.s16),
-        child: Row(
-          children: [
-            const Icon(
-              Icons.cloud_off_rounded,
-              color: AfColors.semanticError,
-              size: 20,
-            ),
-            const SizedBox(width: AfSpacing.s8),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AfTypography.bodyMedium.copyWith(
-                      color: AfColors.textPrimary,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  Text(
-                    displayError(error),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: AfTypography.caption.copyWith(
-                      color: AfColors.textSecondary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: AfSpacing.s8),
-            TextButton(
-              onPressed: onRetry,
-              child: const Text('Retry'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -6,6 +6,7 @@ import '../../core/audio/play_actions.dart';
 import '../../core/jellyfin/models/items.dart';
 import '../../design_tokens/tokens.dart';
 import '../../state/providers.dart';
+import '../../widgets/async_error_view.dart';
 import '../../widgets/tile.dart';
 import '../../widgets/track_context_menu.dart';
 import '../../widgets/track_row.dart';
@@ -280,10 +281,10 @@ class _SectionBody extends ConsumerWidget {
 
     switch (section) {
       case LibrarySection.albums:
-        final albums = isLocal
-            ? ref.watch(localAlbumsProvider)
-            : ref.watch(allAlbumsProvider);
-        return albums.maybeWhen(
+        final albumsProvider =
+            isLocal ? localAlbumsProvider : allAlbumsProvider;
+        final albums = ref.watch(albumsProvider);
+        return albums.when(
           data: (list) {
             final sorted = sortAlbums != null ? sortAlbums!(list) : list;
             return GridView.builder(
@@ -312,13 +313,18 @@ class _SectionBody extends ConsumerWidget {
               },
             );
           },
-          orElse: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => AsyncErrorView(
+            label: 'Couldn\u2019t load albums',
+            error: e,
+            onRetry: () => ref.invalidate(albumsProvider),
+          ),
         );
       case LibrarySection.artists:
-        final artists = isLocal
-            ? ref.watch(localArtistsProvider)
-            : ref.watch(allArtistsProvider);
-        return artists.maybeWhen(
+        final artistsProvider =
+            isLocal ? localArtistsProvider : allArtistsProvider;
+        final artists = ref.watch(artistsProvider);
+        return artists.when(
           data: (list) {
             final sorted = sortArtists != null ? sortArtists!(list) : list;
             return GridView.builder(
@@ -345,14 +351,19 @@ class _SectionBody extends ConsumerWidget {
               },
             );
           },
-          orElse: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => AsyncErrorView(
+            label: 'Couldn\u2019t load artists',
+            error: e,
+            onRetry: () => ref.invalidate(artistsProvider),
+          ),
         );
       case LibrarySection.songs:
         return Consumer(builder: (context, ref, _) {
-          final tracks = isLocal
-              ? ref.watch(localTracksProvider)
-              : ref.watch(allTracksProvider);
-          return tracks.maybeWhen(
+          final tracksProvider =
+              isLocal ? localTracksProvider : allTracksProvider;
+          final tracks = ref.watch(tracksProvider);
+          return tracks.when(
             data: (list) {
               final sorted = sortTracks != null ? sortTracks!(list) : list;
               return ListView.separated(
@@ -376,7 +387,12 @@ class _SectionBody extends ConsumerWidget {
                 },
               );
             },
-            orElse: () => const Center(child: CircularProgressIndicator()),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => AsyncErrorView(
+              label: 'Couldn\u2019t load songs',
+              error: e,
+              onRetry: () => ref.invalidate(tracksProvider),
+            ),
           );
         });
       case LibrarySection.playlists:
@@ -386,7 +402,7 @@ class _SectionBody extends ConsumerWidget {
           data: (list) => list.length,
           orElse: () => 0,
         );
-        return playlists.maybeWhen(
+        return playlists.when(
           data: (list) => ListView.separated(
             padding: padding.add(const EdgeInsets.only(
                 bottom: AfSpacing.bottomInsetWithMiniAndNav)),
@@ -454,13 +470,18 @@ class _SectionBody extends ConsumerWidget {
               );
             },
           ),
-          orElse: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => AsyncErrorView(
+            label: 'Couldn\u2019t load playlists',
+            error: e,
+            onRetry: () => ref.invalidate(allPlaylistsProvider),
+          ),
         );
       case LibrarySection.genres:
-        final genresAsync = isLocal
-            ? ref.watch(localGenresProvider)
-            : ref.watch(allGenresProvider);
-        return genresAsync.maybeWhen(
+        final genresProvider =
+            isLocal ? localGenresProvider : allGenresProvider;
+        final genresAsync = ref.watch(genresProvider);
+        return genresAsync.when(
           data: (genres) => GridView.builder(
             padding: padding.add(const EdgeInsets.only(
                 bottom: AfSpacing.bottomInsetWithMiniAndNav)),
@@ -486,11 +507,16 @@ class _SectionBody extends ConsumerWidget {
               );
             },
           ),
-          orElse: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => AsyncErrorView(
+            label: 'Couldn\u2019t load genres',
+            error: e,
+            onRetry: () => ref.invalidate(genresProvider),
+          ),
         );
       case LibrarySection.liked:
         final likedAsync = ref.watch(favoriteTracksProvider);
-        return likedAsync.maybeWhen(
+        return likedAsync.when(
           data: (list) => list.isEmpty
               ? Center(
                   child: Text(
@@ -519,7 +545,12 @@ class _SectionBody extends ConsumerWidget {
                     );
                   },
                 ),
-          orElse: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => AsyncErrorView(
+            label: 'Couldn\u2019t load liked songs',
+            error: e,
+            onRetry: () => ref.invalidate(favoriteTracksProvider),
+          ),
         );
     }
   }

--- a/lib/widgets/async_error_view.dart
+++ b/lib/widgets/async_error_view.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+import '../design_tokens/tokens.dart';
+import '../utils/display_error.dart';
+
+/// Inline error card for failed `AsyncValue` fetches.
+///
+/// Replaces the `AsyncValue.maybeWhen(data:, orElse: …)` anti-pattern
+/// that used to collapse `loading` **and** `error` into a blank
+/// placeholder (or an infinite spinner). When the server was
+/// unreachable, the auth token had expired, or the backend returned a
+/// 5xx, the user got no feedback — natural read was "library is empty"
+/// or "this is just taking forever".
+///
+/// Two layouts:
+///
+/// - **Compact** (`compactHeight` provided): an inline horizontal row
+///   sized to match the loading skeleton, so layout doesn't jump when
+///   an error surfaces mid-fetch on a Home rail.
+/// - **Centered** (`compactHeight == null`): a centered column suitable
+///   for full-screen sections (Library Albums / Artists / Songs /
+///   Playlists / Genres / Liked).
+///
+/// In both cases the rendered error message goes through
+/// [displayError], which strips the `api_key` / `t` / `s` / `u` query
+/// params Dio embeds in `DioException.toString()`.
+class AsyncErrorView extends StatelessWidget {
+  final String label;
+  final Object error;
+  final VoidCallback onRetry;
+
+  /// When set, renders an inline row of exactly this height. When null,
+  /// renders a centered column with vertical breathing room.
+  final double? compactHeight;
+
+  const AsyncErrorView({
+    super.key,
+    required this.label,
+    required this.error,
+    required this.onRetry,
+  }) : compactHeight = null;
+
+  const AsyncErrorView.compact({
+    super.key,
+    required this.label,
+    required this.error,
+    required this.onRetry,
+    required double height,
+  }) : compactHeight = height;
+
+  @override
+  Widget build(BuildContext context) {
+    final compactHeight = this.compactHeight;
+    if (compactHeight != null) {
+      return SizedBox(
+        height: compactHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AfSpacing.s16),
+          child: Row(
+            children: [
+              const Icon(
+                Icons.cloud_off_rounded,
+                color: AfColors.semanticError,
+                size: 20,
+              ),
+              const SizedBox(width: AfSpacing.s8),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AfTypography.bodyMedium.copyWith(
+                        color: AfColors.textPrimary,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    Text(
+                      displayError(error),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: AfTypography.caption.copyWith(
+                        color: AfColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AfSpacing.s8),
+              TextButton(
+                onPressed: onRetry,
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Centered layout — used by full-screen sections (Library tabs).
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AfSpacing.s24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.cloud_off_rounded,
+              color: AfColors.semanticError,
+              size: 40,
+            ),
+            const SizedBox(height: AfSpacing.s12),
+            Text(
+              label,
+              textAlign: TextAlign.center,
+              style: AfTypography.titleSmall.copyWith(
+                color: AfColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: AfSpacing.s4),
+            Text(
+              displayError(error),
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: AfTypography.bodySmall.copyWith(
+                color: AfColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: AfSpacing.s16),
+            FilledButton.tonal(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

All 6 Library sections — **Albums / Artists / Songs / Playlists / Genres / Liked** — used `AsyncValue.maybeWhen(data:, orElse: CircularProgressIndicator)`. `orElse` is invoked for both `loading` **and** `error`, so when the server was unreachable, the auth token had expired, or the backend returned a 5xx, the user was shown an **infinite spinner forever** with no indication anything had failed.

This was even worse than Home (fixed in #28 which still showed a blank): a spinning indicator strongly implies 'still working, just slow.' Users would wait, retry by switching tabs, and end up convinced the app was broken — with no telemetry on the actual failure.

### Fix

1. **Lifted the inline error widget** from `home_screen.dart` into a new reusable `AsyncErrorView` widget under `lib/widgets/async_error_view.dart`, with two layouts:
   - `AsyncErrorView.compact(height: …)` for Home rails (preserves the existing inline-row UX).
   - `AsyncErrorView(…)` for full-screen sections — a centered column with a `cloud_off` icon, a label, the redacted `displayError` body, and a 'Retry' `FilledButton.tonal` that `ref.invalidate`s the relevant provider.

2. **Library** — switched all 6 sections from `maybeWhen` to `when(data:, loading:, error:)`. `loading:` keeps the existing centered `CircularProgressIndicator`, so the loading-state UX is unchanged. `error:` renders `AsyncErrorView` with a per-section label ("Couldn’t load albums", "Couldn’t load playlists", etc.) and a per-section Retry callback that picks the right provider for the current mode (server vs. local).

3. **Home** — refactored 4 rails to use the new shared widget. No behaviour change; just removes the private `_RailError` class and points to `AsyncErrorView.compact`.

No new dependencies. `flutter analyze` is clean. All 40 existing tests pass.

## Review & Testing Checklist for Human

- [ ] **Force an error on each Library section** (airplane mode + tap Retry; or invalidate auth + tap Retry). Albums / Artists / Songs / Playlists / Genres / Liked each render `AsyncErrorView` with cloud-off icon, label, redacted error, and a Retry button. Error messages must NOT contain `api_key=`, `t=`, `s=`, or `u=` auth params.
- [ ] **Tap Retry on each section** while offline — should re-render the error. Restore network and tap Retry — should re-fetch and show data. No layout jumps or duplicate spinners.
- [ ] **Loading-state regression check** — cold start on each Library tab. Centered `CircularProgressIndicator` should appear during the fetch (unchanged from before).
- [ ] **Local mode regression check** — switch to local mode, navigate through each section. Each Retry button must call the local-mode provider (`localAlbumsProvider`, `localArtistsProvider`, etc.), not the server-mode one. Hint: force a scan failure by unmounting the SAF folder.
- [ ] **Home regression check** — force a Home rail error, the inline error card should look identical to before (visual diff: zero) and Retry should still work per-rail (server- vs. local-mode invalidation).

### Notes

- `_RailError` is gone; the shared widget is `AsyncErrorView`. Two named constructors (`AsyncErrorView` for centered, `AsyncErrorView.compact` for inline) so call sites stay readable.
- The Playlists section reuses `allPlaylistsProvider` for retry — the smart-playlists count was a secondary `maybeWhen` (display-only fallback to 0), left untouched because it has no associated user action.
- Other detail screens (`AlbumScreen`, `PlaylistScreen`, `ArtistScreen`, `GenreScreen`, `SmartPlaylistDetail`) already have their own error handling via `.when(error:)` — not touched in this PR.

Requested by random2 (random2@kasirmatcha.my.id)
Devin session: https://app.devin.ai/sessions/24e9f7f11f6c48c48f8f756a062c7594