### PR TITLE
fix(favorites): sync heart state across screens with override map

### DIFF
--- a/lib/state/providers.dart
+++ b/lib/state/providers.dart
@@ -399,16 +399,53 @@ final fftSpectrumProvider = StreamProvider.autoDispose<FftFrame>((ref) {
 
 final currentTrackProvider = StateProvider<AfTrack?>((ref) => null);
 
+/// Track-level favorite overrides written immediately on heart toggle.
+///
+/// Detail providers ([albumDetailProvider], [playlistDetailProvider],
+/// `artistTopTracks`, [searchProvider], etc.) each cache their own track
+/// list. When the user toggles favorite from one screen and navigates
+/// to another that has the same track cached, the cached
+/// `AfTrack.isFavorite` is stale — so the heart icon shows the
+/// pre-toggle state on every screen except the one where the toggle
+/// happened. Invalidating every detail provider on every favorite
+/// toggle would force a full re-fetch of any actively-watched album /
+/// playlist / search-results list just to flip a single icon, which is
+/// wasteful (the user is paying server round-trips for one bit of
+/// state).
+///
+/// Instead, this map is the authoritative "latest-known" favorite
+/// state per track id. UI that renders a track heart
+/// ([FavoriteHeartButton], Now Playing's icon) consults this map first
+/// and only falls back to the track model's own `isFavorite` field if
+/// no override is present. Writes happen on the optimistic flip (so
+/// every heart for that track id flips in lock-step) and on rollback
+/// after a failed backend call.
+///
+/// Not autoDispose: lives for the session so an override set early in
+/// the app's life is still respected on screens visited much later.
+/// The map is bounded by the number of distinct tracks the user has
+/// favorited this session, so unbounded growth in practice isn't a
+/// concern.
+final trackFavoriteOverridesProvider =
+    StateProvider<Map<String, bool>>((ref) => const {});
+
 final favoriteToggleProvider = Provider<Future<void> Function(AfTrack)>((ref) {
   return (AfTrack track) async {
     final backend = ref.read(musicBackendProvider);
-    final next = !track.isFavorite;
+    // `trackFavoriteOverridesProvider` is the latest-known state — fall
+    // back to the model only when no override is present.
+    final overrides = ref.read(trackFavoriteOverridesProvider);
+    final wasFavorite = overrides[track.id] ?? track.isFavorite;
+    final next = !wasFavorite;
     final updated = track.copyWith(isFavorite: next);
     final current = ref.read(currentTrackProvider);
 
     if (current?.id == track.id) {
       ref.read(currentTrackProvider.notifier).state = updated;
     }
+    ref.read(trackFavoriteOverridesProvider.notifier).update(
+          (s) => {...s, track.id: next},
+        );
 
     if (backend == null) {
       _logData('favoriteToggle',
@@ -428,6 +465,9 @@ final favoriteToggleProvider = Provider<Future<void> Function(AfTrack)>((ref) {
       if (current?.id == track.id) {
         ref.read(currentTrackProvider.notifier).state = track;
       }
+      ref.read(trackFavoriteOverridesProvider.notifier).update(
+            (s) => {...s, track.id: wasFavorite},
+          );
       rethrow;
     }
   };

--- a/lib/widgets/favorite_heart_button.dart
+++ b/lib/widgets/favorite_heart_button.dart
@@ -9,10 +9,13 @@ import '../utils/log.dart';
 
 /// Tappable heart button for a single [AfTrack].
 ///
-/// Drives `backend.setFavorite(trackId, next)` directly and manages an
-/// **optimistic local flip** so the icon updates on the next frame —
-/// the round-trip to the server is hidden behind the user's tap. On
-/// failure the flip is reverted and a `SnackBar` surfaces `displayError`.
+/// Drives `backend.setFavorite(trackId, next)` directly and writes the
+/// **optimistic flip** into the session-wide
+/// [trackFavoriteOverridesProvider] so every heart for the same track
+/// id — on the album screen, the playlist screen, search results, the
+/// Now Playing icon — flips in lock-step. The round-trip to the server
+/// is hidden behind the user's tap. On failure the override is rolled
+/// back to the previous value and a `SnackBar` surfaces `displayError`.
 ///
 /// This widget replaces the previously-dead `onHeartTap` callback hole
 /// in [TrackRow]: every list screen that rendered a `TrackRow` with
@@ -30,10 +33,12 @@ import '../utils/log.dart';
 /// when the tapped track is the one currently playing — otherwise the
 /// Now Playing screen would lag behind a list-screen toggle.
 ///
-/// Uses `didUpdateWidget` to re-seed local state when the parent
-/// re-fetches the track (e.g. after a favorite-provider invalidation)
-/// — but skips re-seeding while a toggle is in flight so the optimistic
-/// state isn't clobbered.
+/// Displayed state is derived from
+/// `trackFavoriteOverridesProvider[track.id] ?? track.isFavorite`, so
+/// a toggle from anywhere is reflected here as soon as Riverpod
+/// rebuilds — no `didUpdateWidget` / local mirror dance needed.
+/// `_busy` stays local because it gates *this* button's request, not
+/// the global toggle state.
 class FavoriteHeartButton extends ConsumerStatefulWidget {
   /// The track to favorite/unfavorite. Only `id` and `isFavorite` are
   /// read; the rest of the model is forwarded to `currentTrackProvider`
@@ -56,39 +61,32 @@ class FavoriteHeartButton extends ConsumerStatefulWidget {
 }
 
 class _FavoriteHeartButtonState extends ConsumerState<FavoriteHeartButton> {
-  late bool _isFavorite;
   bool _busy = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _isFavorite = widget.track.isFavorite;
-  }
-
-  @override
-  void didUpdateWidget(covariant FavoriteHeartButton old) {
-    super.didUpdateWidget(old);
-    // Sync with parent when the source-of-truth track changes — but not
-    // mid-toggle, so we don't clobber the optimistic flip with the stale
-    // pre-toggle value.
-    if (!_busy && old.track.isFavorite != widget.track.isFavorite) {
-      _isFavorite = widget.track.isFavorite;
-    }
-  }
+  /// Authoritative "is this track favorited *right now*" — overrides
+  /// the (potentially stale) `widget.track.isFavorite` field cached on
+  /// whatever provider produced the track list.
+  bool _isFavoriteFromOverrides(Map<String, bool> overrides) =>
+      overrides[widget.track.id] ?? widget.track.isFavorite;
 
   Future<void> _toggle() async {
     if (_busy) return;
     final backend = ref.read(musicBackendProvider);
     if (backend == null) return; // signed-out / demo mode
 
-    final next = !_isFavorite;
-    setState(() {
-      _busy = true;
-      _isFavorite = next;
-    });
+    final overrides = ref.read(trackFavoriteOverridesProvider);
+    final wasFavorite = _isFavoriteFromOverrides(overrides);
+    final next = !wasFavorite;
+    setState(() => _busy = true);
+
+    // Optimistic global flip — every heart for this track id rebuilds
+    // immediately, including this one (via the `ref.watch` in `build`).
+    ref.read(trackFavoriteOverridesProvider.notifier).update(
+          (s) => {...s, widget.track.id: next},
+        );
 
     // Keep `currentTrackProvider` in sync if this is the playing track,
-    // so Now Playing's heart icon doesn't lag a list-screen toggle.
+    // so Now Playing's icon doesn't lag a list-screen toggle.
     final current = ref.read(currentTrackProvider);
     if (current?.id == widget.track.id) {
       ref.read(currentTrackProvider.notifier).state =
@@ -110,8 +108,11 @@ class _FavoriteHeartButtonState extends ConsumerState<FavoriteHeartButton> {
       afLog('error', 'trackFavorite toggle failed',
           error: e, stackTrace: stack);
       if (!mounted) return;
-      setState(() => _isFavorite = !next);
-      // Revert the playing-track copy if we were the source of truth.
+      // Roll the override back to the pre-toggle value (which itself
+      // might have been an earlier override or the model default).
+      ref.read(trackFavoriteOverridesProvider.notifier).update(
+            (s) => {...s, widget.track.id: wasFavorite},
+          );
       if (current?.id == widget.track.id) {
         ref.read(currentTrackProvider.notifier).state = current;
       }
@@ -128,14 +129,16 @@ class _FavoriteHeartButtonState extends ConsumerState<FavoriteHeartButton> {
 
   @override
   Widget build(BuildContext context) {
+    final overrides = ref.watch(trackFavoriteOverridesProvider);
+    final isFavorite = _isFavoriteFromOverrides(overrides);
     return IconButton(
       icon: Icon(
-        _isFavorite ? Icons.favorite : Icons.favorite_border,
-        color: _isFavorite ? AfColors.semanticError : AfColors.textTertiary,
+        isFavorite ? Icons.favorite : Icons.favorite_border,
+        color: isFavorite ? AfColors.semanticError : AfColors.textTertiary,
         size: widget.size,
       ),
       onPressed: _toggle,
-      tooltip: _isFavorite ? 'Unfavorite' : 'Favorite',
+      tooltip: isFavorite ? 'Unfavorite' : 'Favorite',
       padding: EdgeInsets.zero,
       visualDensity: VisualDensity.compact,
       constraints: const BoxConstraints(


### PR DESCRIPTION
## Summary

Toggling a track's heart from Now Playing or one list screen left **every other cached track list** showing the old `isFavorite` value. `albumDetailProvider`, `playlistDetailProvider`, `artistTopTracksProvider`, `searchProvider`, and the Home rails each fetch a list of `AfTrack` whose `isFavorite` field is snapshotted at fetch time. After a toggle, only the screen that did the toggle reflects it (locally) — every back-stack screen with the same track in its list shows the stale heart until the user pulls to refresh, which round-trips the full album/playlist just to flip one icon.

Repro:

1. Open the Album screen for an album containing track X. X.isFavorite = false. Heart shows empty.
2. Tap the mini-player to open Now Playing for the same track. Tap the heart — X is favorited (heart fills, server is updated).
3. Swipe back down to the Album screen. Track X's row still shows the empty heart — the album list was already cached with the pre-toggle `isFavorite` snapshot.

### Fix

Introduce a session-wide `trackFavoriteOverridesProvider: StateProvider<Map<String, bool>>` that holds the latest-known favorite state per track id. Both toggle entry points (`favoriteToggleProvider` from Now Playing, `FavoriteHeartButton._toggle` from list-screen track rows) write the optimistic value into this map *before* the backend round-trip and roll it back on error.

`FavoriteHeartButton` watches the map and derives its displayed state as `overrides[track.id] ?? widget.track.isFavorite` — so every heart for the same track id rebuilds in lock-step the instant any one of them is tapped, even though the originating provider's cache is unchanged.

This is materially cheaper than the obvious alternative of invalidating every detail provider on every favorite toggle, which would force a full re-fetch of any actively-watched detail screen just to flip one bit. The override is bounded by the number of distinct tracks the user toggles in a session.

Drops the `didUpdateWidget` re-seed dance from `FavoriteHeartButton` — no longer needed because state is no longer mirrored locally. `_busy` stays local since it gates *this* button's in-flight request, not the global toggle state.

`flutter analyze` is clean. All 40 existing tests pass.

## Review & Testing Checklist for Human

- [ ] **Cross-screen sync** — reproduce the 3-step repro above. Confirm the Album screen heart updates when you swipe down from Now Playing. Then do the inverse: tap the heart on a list-screen row, then open Now Playing for that same track — its icon should already be filled.
- [ ] **Search results sync** — search for a track, tap its heart, then navigate to that track's album/playlist. The heart on the destination screen should already reflect the toggle.
- [ ] **Optimistic flip + error rollback** — force a `setFavorite` failure (airplane mode, expired token). Tap the heart on any screen. The heart should flip optimistically, then *roll back* on the SnackBar error. Confirm rollback happens on every cached screen, not just the originating one.
- [ ] **Now Playing-only toggle still works** — toggle from Now Playing screen, confirm the icon updates correctly and the favorite-tracks rail on Home refreshes.
- [ ] **List-screen toggle still works** — toggle from Album / Playlist / Search row, confirm same.
- [ ] **Same-track in different lists** — if a track appears in multiple loaded lists (e.g. Recently Played + Album + Liked), tapping one heart flips all of them in lock-step.

### Notes

- The override map is `StateProvider` (not `autoDispose`) so it survives screen disposal — a toggle in early-session is still respected on a screen visited 30 minutes later.
- No backend or model changes. Only `lib/state/providers.dart` and `lib/widgets/favorite_heart_button.dart`.
- Album-level favorites (`_ActionRowState` in `album_screen.dart`) are out of scope — they target `AfAlbum.isFavorite`, not `AfTrack.isFavorite`. Could get the same treatment in a follow-up.
- The Now Playing heart icon doesn't need to watch the override map directly because both toggle paths update `currentTrackProvider`, which Now Playing already reads.

Requested by random2 (random2@kasirmatcha.my.id)
Devin session: https://app.devin.ai/sessions/24e9f7f11f6c48c48f8f756a062c7594